### PR TITLE
OPS-006: make local check matrix green and one-shot via make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,31 @@
 VER := $(shell git describe --tag)
 SHA1 := $(shell git rev-parse HEAD)
 NOW := $(shell date -u +'%Y-%m-%d_%TZ')
+GOBIN := $(shell go env GOPATH)/bin
 
-check:
-	@echo Linting
-	golangci-lint run
+.PHONY: fmt vet lint sec test-race verify
+fmt:
+	@echo "==> gofmt"
+	@out=$$(gofmt -l .); if [ -n "$$out" ]; then echo "$$out"; echo "files need gofmt"; exit 1; fi
 
-	@echo Security scanning
-	gosec ./...
+vet:
+	@echo "==> go vet"
+	go vet ./...
 
-	@echo Testing
-	go test ./...
+lint:
+	@echo "==> golangci-lint"
+	@command -v golangci-lint >/dev/null 2>&1 && golangci-lint run || $(GOBIN)/golangci-lint run
+
+sec:
+	@echo "==> gosec"
+	@command -v gosec >/dev/null 2>&1 && gosec ./... || $(GOBIN)/gosec ./...
+
+test-race:
+	@echo "==> go test -race"
+	go test -race -count=1 -timeout 60s ./...
+
+verify: fmt vet lint sec test-race
+	@echo "==> verify OK"
 
 build:
 	@echo Building the binary
@@ -33,5 +48,5 @@ docker:
 		--build-arg SHA1=$(SHA1) .
 
 tools:
-	go install github.com/securego/gosec/v2/cmd/gosec
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest

--- a/README.md
+++ b/README.md
@@ -96,6 +96,42 @@ The testing in this project is pretty bare-bones and mostly just proof-of-concep
 though, they're in [api](api). I personally prefer more integration tests that test an application front-to-back for 
 features rather than tons and tons of tightly-coupled unit tests.
 
+The default `go test ./...` runs the unit tests only. To run the full local
+check matrix in one go, use `make verify`. See [Make targets](#make-targets)
+below for what each step does.
+
+The integration tests in [cmd/integration_test.go](cmd/integration_test.go)
+require Postgres and RabbitMQ (see [docker-compose.yml](docker-compose.yml))
+and are gated behind the `integration` build tag. Run them with:
+
+```shell
+docker-compose up -d
+go test -tags=integration ./cmd/...
+```
+
+### Make targets
+
+`make verify` is the entry point most contributors want — it chains every
+local check and fails fast on the first one. The individual targets are also
+exposed so you can run a single step in isolation:
+
+| Target | What it does |
+| --- | --- |
+| `make tools` | Installs `golangci-lint` and `gosec` into `$(go env GOPATH)/bin`. Run once before `make verify`, and re-run when bumping versions. |
+| `make fmt` | Runs `gofmt -l .` and exits non-zero if any file needs formatting. Does not modify files — fix with `gofmt -w <file>`. |
+| `make vet` | Runs `go vet ./...`. |
+| `make lint` | Runs `golangci-lint run` with the project defaults. |
+| `make sec` | Runs `gosec ./...` (CWE-tagged static analysis). |
+| `make test-race` | Runs `go test -race -count=1 -timeout 60s ./...`. |
+| `make verify` | Runs `fmt`, `vet`, `lint`, `sec`, and `test-race` in order. |
+| `make test` | Runs `go test -cover ./...` without race detection — quick smoke check. |
+| `make build` | Builds the binary into `./bin/go-micro-example` with version metadata baked in. |
+| `make run` | Runs the application via `go run ./cmd/.`. Requires Postgres and RabbitMQ. |
+| `make docker` | Builds the Docker image. |
+
+If `make tools` has not been run yet, `lint` and `sec` will fail with
+`command not found`; install the tools first.
+
 ### Database Migrations
 
 I'm using the [migrate](https://github.com/golang-migrate/migrate) project to manage database migrations.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/go-chi/chi"
@@ -22,24 +21,10 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// The Metrics middleware registers global Prometheus collectors on every call
-// to ConfigureRouter, which panics on a second call within the same process.
-// Until that is addressed (out of scope for SEC-001), share a single router
-// across tests in this file.
-var (
-	sharedRouterOnce sync.Once
-	sharedRouter     chi.Router
-	sharedUserSvc    *user.MockUserService
-)
-
-func sharedTestRouter() (chi.Router, *user.MockUserService) {
-	sharedRouterOnce.Do(func() {
-		cfg := config.LoadDefaults()
-		invSvc, resSvc, usrSvc := getMocks()
-		sharedUserSvc = usrSvc
-		sharedRouter = api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc)
-	})
-	return sharedRouter, sharedUserSvc
+func newTestRouter() (chi.Router, *user.MockUserService) {
+	cfg := config.LoadDefaults()
+	invSvc, resSvc, usrSvc := getMocks()
+	return api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc), usrSvc
 }
 
 func TestCorsConfig(t *testing.T) {
@@ -59,7 +44,7 @@ func TestCorsConfig(t *testing.T) {
 		{origin: "https://localhostevil:3000", want: ""},
 	}
 
-	r, _ := sharedTestRouter()
+	r, _ := newTestRouter()
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
@@ -86,15 +71,10 @@ func TestCorsConfig(t *testing.T) {
 }
 
 func TestApiRoutesRequireAuthentication(t *testing.T) {
-	r, usrSvc := sharedTestRouter()
+	r, usrSvc := newTestRouter()
 	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
 		return user.User{}, core.ErrNotFound
 	}
-	t.Cleanup(func() {
-		usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
-			return user.User{}, nil
-		}
-	})
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
@@ -142,7 +122,7 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 }
 
 func TestUnauthenticatedEndpointsRemainOpen(t *testing.T) {
-	r, _ := sharedTestRouter()
+	r, _ := newTestRouter()
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 

--- a/api/inventoryapi_test.go
+++ b/api/inventoryapi_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gobwas/ws"
 	"github.com/sksmith/go-micro-example/api"
@@ -22,12 +23,12 @@ import (
 func TestInventorySubscribe(t *testing.T) {
 	mockSvc := inventory.NewMockInventoryService()
 
-	subscribeCalled := false
+	subscribed := make(chan struct{}, 1)
+	unsubscribed := make(chan struct{}, 1)
 	expectedSubId := inventory.InventorySubID("subid1")
-	unsubscribeCalled := false
 
 	mockSvc.SubscribeInventoryFunc = func(ch chan<- inventory.ProductInventory) (id inventory.InventorySubID) {
-		subscribeCalled = true
+		subscribed <- struct{}{}
 		go func() {
 			inv := getTestProductInventory()
 			for i := 0; i < 3; i++ {
@@ -40,7 +41,7 @@ func TestInventorySubscribe(t *testing.T) {
 	}
 
 	mockSvc.UnsubscribeInventoryFunc = func(id inventory.InventorySubID) {
-		unsubscribeCalled = true
+		unsubscribed <- struct{}{}
 	}
 
 	invApi := api.NewInventoryApi(mockSvc)
@@ -66,11 +67,15 @@ func TestInventorySubscribe(t *testing.T) {
 		}
 	}
 
-	if !subscribeCalled {
+	select {
+	case <-subscribed:
+	case <-time.After(time.Second):
 		t.Errorf("subscribe never called")
 	}
 
-	if !unsubscribeCalled {
+	select {
+	case <-unsubscribed:
+	case <-time.After(time.Second):
 		t.Errorf("unsubscribe never called")
 	}
 }

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -129,15 +130,21 @@ func Logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-func Metrics(next http.Handler) http.Handler {
-	urlHitCount := prometheus.NewCounterVec(
+var (
+	metricsOnce sync.Once
+	urlHitCount *prometheus.CounterVec
+	urlLatency  *prometheus.SummaryVec
+)
+
+func initMetrics() {
+	urlHitCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "url_hit_count",
 			Help: "Number of times the given url was hit",
 		},
 		[]string{"method", "url"},
 	)
-	urlLatency := prometheus.NewSummaryVec(
+	urlLatency = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "url_latency",
 			Help:       "The latency quantiles for the given URL",
@@ -148,6 +155,10 @@ func Metrics(next http.Handler) http.Handler {
 
 	prometheus.MustRegister(urlHitCount)
 	prometheus.MustRegister(urlLatency)
+}
+
+func Metrics(next http.Handler) http.Handler {
+	metricsOnce.Do(initMetrics)
 
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/api/reservationapi_test.go
+++ b/api/reservationapi_test.go
@@ -21,12 +21,12 @@ import (
 func TestReservationSubscribe(t *testing.T) {
 	mockSvc := inventory.NewMockReservationService()
 
-	subscribeCalled := false
+	subscribed := make(chan struct{}, 1)
+	unsubscribed := make(chan struct{}, 1)
 	expectedSubId := inventory.ReservationsSubID("subid1")
-	unsubscribeCalled := false
 
 	mockSvc.SubscribeReservationsFunc = func(ch chan<- inventory.Reservation) (id inventory.ReservationsSubID) {
-		subscribeCalled = true
+		subscribed <- struct{}{}
 		go func() {
 			res := getTestReservations()
 			for i := 0; i < 3; i++ {
@@ -39,7 +39,7 @@ func TestReservationSubscribe(t *testing.T) {
 	}
 
 	mockSvc.UnsubscribeReservationsFunc = func(id inventory.ReservationsSubID) {
-		unsubscribeCalled = true
+		unsubscribed <- struct{}{}
 	}
 
 	resApi := api.NewReservationApi(mockSvc)
@@ -63,11 +63,15 @@ func TestReservationSubscribe(t *testing.T) {
 		reflect.DeepEqual(got, curRes[i])
 	}
 
-	if !subscribeCalled {
+	select {
+	case <-subscribed:
+	case <-time.After(time.Second):
 		t.Errorf("subscribe never called")
 	}
 
-	if !unsubscribeCalled {
+	select {
+	case <-unsubscribed:
+	case <-time.After(time.Second):
 		t.Errorf("unsubscribe never called")
 	}
 }

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package main
 
 import (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,15 @@ func main() {
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 
 	log.Info().Str("port", cfg.Port.Value).Int64("startTimeMs", time.Since(start).Milliseconds()).Msg("listening")
-	log.Fatal().Err(http.ListenAndServe(":"+cfg.Port.Value, r))
+	srv := &http.Server{
+		Addr:              ":" + cfg.Port.Value,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	log.Fatal().Err(srv.ListenAndServe())
 }
 
 func printLogHeader(cfg *config.Config) {

--- a/core/inventory/service.go
+++ b/core/inventory/service.go
@@ -2,6 +2,7 @@ package inventory
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,6 +33,7 @@ type GetReservationsOptions struct {
 type service struct {
 	repo            Repository
 	queue           InventoryQueue
+	subsMu          sync.Mutex
 	inventorySubs   map[InventorySubID]chan<- ProductInventory
 	reservationSubs map[ReservationsSubID]chan<- Reservation
 }
@@ -291,28 +293,40 @@ func (s *service) GetReservations(ctx context.Context, options GetReservationsOp
 
 func (s *service) SubscribeInventory(ch chan<- ProductInventory) (id InventorySubID) {
 	id = InventorySubID(uuid.NewString())
+	s.subsMu.Lock()
 	s.inventorySubs[id] = ch
+	s.subsMu.Unlock()
 	log.Debug().Interface("clientId", id).Msg("subscribing to inventory")
 	return id
 }
 
 func (s *service) UnsubscribeInventory(id InventorySubID) {
 	log.Debug().Interface("clientId", id).Msg("unsubscribing from inventory")
-	close(s.inventorySubs[id])
-	delete(s.inventorySubs, id)
+	s.subsMu.Lock()
+	if ch, ok := s.inventorySubs[id]; ok {
+		close(ch)
+		delete(s.inventorySubs, id)
+	}
+	s.subsMu.Unlock()
 }
 
 func (s *service) SubscribeReservations(ch chan<- Reservation) (id ReservationsSubID) {
 	id = ReservationsSubID(uuid.NewString())
+	s.subsMu.Lock()
 	s.reservationSubs[id] = ch
+	s.subsMu.Unlock()
 	log.Debug().Interface("clientId", id).Msg("subscribing to reservations")
 	return id
 }
 
 func (s *service) UnsubscribeReservations(id ReservationsSubID) {
 	log.Debug().Interface("clientId", id).Msg("unsubscribing from reservations")
-	close(s.reservationSubs[id])
-	delete(s.reservationSubs, id)
+	s.subsMu.Lock()
+	if ch, ok := s.reservationSubs[id]; ok {
+		close(ch)
+		delete(s.reservationSubs, id)
+	}
+	s.subsMu.Unlock()
 }
 
 func (s *service) FillReserves(ctx context.Context, product Product) error {
@@ -437,14 +451,28 @@ func (s *service) publishReservation(ctx context.Context, r Reservation) error {
 }
 
 func (s *service) notifyInventorySubscribers(pi ProductInventory) {
+	s.subsMu.Lock()
+	subs := make(map[InventorySubID]chan<- ProductInventory, len(s.inventorySubs))
 	for id, ch := range s.inventorySubs {
+		subs[id] = ch
+	}
+	s.subsMu.Unlock()
+
+	for id, ch := range subs {
 		log.Debug().Interface("clientId", id).Interface("productInventory", pi).Msg("notifying subscriber of inventory update")
 		ch <- pi
 	}
 }
 
 func (s *service) notifyReservationSubscribers(r Reservation) {
+	s.subsMu.Lock()
+	subs := make(map[ReservationsSubID]chan<- Reservation, len(s.reservationSubs))
 	for id, ch := range s.reservationSubs {
+		subs[id] = ch
+	}
+	s.subsMu.Unlock()
+
+	for id, ch := range subs {
 		log.Debug().Interface("clientId", id).Interface("productInventory", r).Msg("notifying subscriber of reservation update")
 		ch <- r
 	}

--- a/core/inventory/service_test.go
+++ b/core/inventory/service_test.go
@@ -1156,7 +1156,7 @@ func TestSubscribeInventory(t *testing.T) {
 	id := service.SubscribeInventory(ch)
 
 	go func() {
-		service.Produce(context.Background(), getProductInventory()[2].Product, inventory.ProductionRequest{RequestID: "request1", Quantity: 1})
+		_ = service.Produce(context.Background(), getProductInventory()[2].Product, inventory.ProductionRequest{RequestID: "request1", Quantity: 1})
 	}()
 
 	want := getProductInventory()[2]
@@ -1201,7 +1201,7 @@ func TestSubscribeReservations(t *testing.T) {
 	id := service.SubscribeReservations(ch)
 
 	go func() {
-		service.Produce(context.Background(), getProductInventory()[2].Product, inventory.ProductionRequest{RequestID: "request1", Quantity: 10})
+		_ = service.Produce(context.Background(), getProductInventory()[2].Product, inventory.ProductionRequest{RequestID: "request1", Quantity: 10})
 	}()
 
 	want := getReservations()[3]

--- a/core/user/model.go
+++ b/core/user/model.go
@@ -9,8 +9,8 @@ type CreateUserRequest struct {
 }
 
 type User struct {
-	Username string
+	Username       string
 	HashedPassword string
-	IsAdmin bool
-	Created time.Time
+	IsAdmin        bool
+	Created        time.Time
 }

--- a/db/db.go
+++ b/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -10,6 +11,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/config"
@@ -52,6 +54,13 @@ func newDbConfig() dbconfig {
 	}
 }
 
+func poolSizeToInt32(v int64, name string) (int32, error) {
+	if v < 0 || v > math.MaxInt32 {
+		return 0, errors.Errorf("%s out of range for int32: %d", name, v)
+	}
+	return int32(v), nil
+}
+
 func formatOption(url, option string, value interface{}) string {
 	return url + " " + option + "=" + fmt.Sprintf("%v", value)
 }
@@ -91,7 +100,15 @@ func ConnectDb(ctx context.Context, cfg *config.Config) (*pgxpool.Pool, error) {
 
 	var pool *pgxpool.Pool
 
-	url := addOptionsToConnStr(connStr, MinPoolConns(int32(cfg.Db.Pool.MinSize.Value)), MaxPoolConns(int32(cfg.Db.Pool.MaxSize.Value)))
+	minConns, err := poolSizeToInt32(cfg.Db.Pool.MinSize.Value, "db.pool.minSize")
+	if err != nil {
+		return nil, err
+	}
+	maxConns, err := poolSizeToInt32(cfg.Db.Pool.MaxSize.Value, "db.pool.maxSize")
+	if err != nil {
+		return nil, err
+	}
+	url := addOptionsToConnStr(connStr, MinPoolConns(minConns), MaxPoolConns(maxConns))
 	poolConfig, err := pgxpool.ParseConfig(url)
 	if err != nil {
 		return nil, err

--- a/db/metrics.go
+++ b/db/metrics.go
@@ -34,7 +34,7 @@ var (
 
 type Metric struct {
 	funcName string
-	start time.Time
+	start    time.Time
 }
 
 func StartMetric(funcName string) *Metric {


### PR DESCRIPTION
## Summary

Unblocks every later ticket from inheriting a red baseline. Before this change, none of the standard local checks from `plan/README.md` step 6 could pass on master:

- `cmd` integration test hung waiting on Postgres/RabbitMQ → gated behind `//go:build integration`.
- Two websocket tests reported data races, and the underlying `inventory.service` subscription maps were unsynchronised → added a `Mutex`, snapshot-before-send in the notify path, channel-based test signalling.
- `api.Metrics` middleware re-registered global Prometheus collectors on every `ConfigureRouter` call → moved registration into a `sync.Once`-guarded init; dropped the test-only shim from SEC-001.
- `gofmt -l .` was dirty on master → reformatted [core/user/model.go](../tree/OPS-006-test-suite-hygiene/core/user/model.go) and [db/metrics.go](../tree/OPS-006-test-suite-hygiene/db/metrics.go).
- `golangci-lint v1.43.0` (pinned in `make tools`) failed typecheck against modern Go → bumped to `@latest` and fixed the two `errcheck` findings it surfaced.
- `gosec` flagged three production-code issues (G114 missing http timeouts, G115 int64→int32 overflow ×2). Fixed inline rather than deferring: cmd/main.go now uses an `http.Server` with read/write/idle timeouts, and db pool sizes go through a bounds-checked helper.
- New focused make targets: `fmt`, `vet`, `lint`, `sec`, `test-race`, composed by a new `verify` target. Old `check` target removed. README documents every target. `lint` and `sec` look up tools on PATH first, falling back to `$(go env GOPATH)/bin/<tool>` so PATH setup isn't required.

Ticket: [plan/OPS-006-test-suite-hygiene.md](../tree/OPS-006-test-suite-hygiene/plan/OPS-006-test-suite-hygiene.md) (gitignored locally).

### Acceptance criteria

- [x] `go test ./...` exits 0 within 60s.
- [x] `go test ./... -race` exits 0; `Test*Subscribe` are race-free and the underlying service is too.
- [x] `gofmt -l .` produces no output.
- [x] `ConfigureRouter` can be called more than once per process.
- [x] README documents the make targets and how to run unit vs integration tests.
- [x] `make verify` runs fmt + vet + lint + sec + test-race in one shot and exits 0 on a clean checkout (after `make tools`).

### Notes / scope decisions

- The G114 fix adds timeouts to `http.ListenAndServe`. Graceful shutdown (signal handling, `srv.Shutdown(ctx)`) is intentionally left for [DSN-001](../tree/OPS-006-test-suite-hygiene/plan/DSN-001-graceful-shutdown.md) — this PR only stops the bleeding on the gosec finding.
- Bumping `golangci-lint` to `@latest` is a deliberate trade-off: pinning to a specific newer version (e.g. `v1.64.x`) would be more reproducible. Happy to change if you'd rather pin.
- The two `errcheck` fixes use `_ =` rather than asserting on the error inside the goroutine, since the test logic doesn't depend on the result. If you'd prefer a `t.Errorf`, easy follow-up.

## Test plan

- [x] `make tools` (or `go install ...@<ver>` equivalent)
- [x] `make verify` — green
- [x] `go test -race -count=1 ./...` — green
- [x] `gofmt -l .` — empty
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gosec ./...` — 0 issues
- [ ] (Optional) `docker-compose up -d && go test -tags=integration ./cmd/...` to confirm the integration tag still routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)