### PR TITLE
SEC-013: gate /env behind admin auth and redact sensitive fields

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,13 +16,14 @@ import (
 
 const (
 	HealthEndpoint  = "/health"
-	EnvEndpoint     = "/env"
 	MetricsEndpoint = "/metrics"
 
 	ApiPath         = "/api/v1"
 	InventoryPath   = "/inventory"
 	ReservationPath = "/reservation"
 	UserPath        = "/user"
+	AdminPath       = "/admin"
+	EnvPath         = "/env"
 )
 
 // ConfigureRouter instantiates a go-chi router with middleware and routes for the server
@@ -44,17 +45,19 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Use(Logging)
 
-	r.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc(HealthEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("UP"))
 	})
-	r.Handle("/metrics", promhttp.Handler())
-	r.Route("/env", NewEnvApi(cfg).ConfigureRouter)
+	r.Handle(MetricsEndpoint, promhttp.Handler())
 
 	r.With(Authenticate(userService)).Route(ApiPath, func(r chi.Router) {
 		r.Route(InventoryPath, NewInventoryApi(invSvc).ConfigureRouter)
 		r.Route(ReservationPath, NewReservationApi(resSvc).ConfigureRouter)
 		r.Route(UserPath, NewUserApi(userService).ConfigureRouter)
+		r.With(AdminOnly).Route(AdminPath, func(r chi.Router) {
+			r.Route(EnvPath, NewEnvApi(cfg).ConfigureRouter)
+		})
 	})
 
 	return r

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -85,6 +85,7 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 		{"inventory", api.ApiPath + api.InventoryPath},
 		{"reservation", api.ApiPath + api.ReservationPath},
 		{"user", api.ApiPath + api.UserPath},
+		{"admin/env", api.ApiPath + api.AdminPath + api.EnvPath},
 	}
 
 	for _, test := range tests {

--- a/api/environmentapi_test.go
+++ b/api/environmentapi_test.go
@@ -1,13 +1,17 @@
 package api_test
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi"
 	"github.com/sksmith/go-micro-example/api"
 	"github.com/sksmith/go-micro-example/config"
+	"github.com/sksmith/go-micro-example/core/user"
 	"github.com/sksmith/go-micro-example/testutil"
 )
 
@@ -30,5 +34,94 @@ func TestGetEnvironment(t *testing.T) {
 
 	if got.AppName != cfg.AppName {
 		t.Errorf("unexpected app name got=[%v] want=[%v]", got, cfg.AppName)
+	}
+}
+
+func TestEnvEndpointRedactsSensitiveValues(t *testing.T) {
+	const (
+		dbPass     = "super-secret-db-password"
+		rabbitPass = "super-secret-mq-password"
+		dbHost     = "internal-db.prod"
+		rabbitHost = "internal-mq.prod"
+		dbUser     = "prod-db-user"
+		rabbitUser = "prod-mq-user"
+		springUrl  = "https://config.internal/prod"
+		springUser = "spring-user"
+		springPass = "spring-pass"
+	)
+
+	cfg := config.LoadDefaults()
+	cfg.Db.Pass.Value = dbPass
+	cfg.Db.Host.Value = dbHost
+	cfg.Db.User.Value = dbUser
+	cfg.RabbitMQ.Pass.Value = rabbitPass
+	cfg.RabbitMQ.Host.Value = rabbitHost
+	cfg.RabbitMQ.User.Value = rabbitUser
+	cfg.Config.Spring.Url.Value = springUrl
+	cfg.Config.Spring.User.Value = springUser
+	cfg.Config.Spring.Pass.Value = springPass
+
+	envApi := api.NewEnvApi(cfg)
+	r := chi.NewRouter()
+	envApi.ConfigureRouter(r)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+
+	leaks := []string{dbPass, rabbitPass, dbHost, rabbitHost, dbUser, rabbitUser, springUrl, springUser, springPass}
+	for _, leak := range leaks {
+		if strings.Contains(string(body), leak) {
+			t.Errorf("/env response leaked sensitive value %q", leak)
+		}
+	}
+}
+
+func TestEnvEndpointRequiresAdmin(t *testing.T) {
+	r, usrSvc := newTestRouter()
+	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
+		return user.User{Username: "regular", IsAdmin: false}, nil
+	}
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	envURL := ts.URL + api.ApiPath + api.AdminPath + api.EnvPath
+
+	req, err := http.NewRequest(http.MethodGet, envURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.SetBasicAuth("regular", "pw")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for non-admin user, got %d", res.StatusCode)
+	}
+}
+
+func TestOldEnvPathIsGone(t *testing.T) {
+	r, _ := newTestRouter()
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 at unauthenticated /env, got %d", res.StatusCode)
 	}
 }

--- a/api/util.go
+++ b/api/util.go
@@ -16,24 +16,45 @@ func Scrub(o interface{}) {
 	for i := 0; i < t.NumField(); i++ {
 		f := v.Field(i)
 		sf := t.Field(i)
+		tagged := sf.Tag.Get("sensitive") != ""
+
+		if tagged {
+			redact(f, sf.Name)
+			continue
+		}
 		if f.Kind() == reflect.Struct {
 			Scrub(v.Field(i).Addr().Interface())
 		}
-		if sf.Tag.Get("sensitive") != "" {
-			switch f.Kind() {
-			case reflect.String:
-				f.SetString("******")
-			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				f.SetInt(0)
-			case reflect.Float32, reflect.Float64:
-				f.SetFloat(0.00)
-			default:
-				log.Warn().
-					Str("fieldName", sf.Name).
-					Str("type", f.Kind().String()).
-					Msg("field marked sensitive but was an unrecognized type")
-			}
+	}
+}
+
+// redact zeroes a leaf field, or — for the wrapped *Config types in this
+// project — zeroes the inner Value field of a tagged struct.
+func redact(f reflect.Value, name string) {
+	switch f.Kind() {
+	case reflect.String:
+		f.SetString("******")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		f.SetInt(0)
+	case reflect.Float32, reflect.Float64:
+		f.SetFloat(0.00)
+	case reflect.Bool:
+		f.SetBool(false)
+	case reflect.Struct:
+		inner := f.FieldByName("Value")
+		if inner.IsValid() && inner.CanSet() {
+			redact(inner, name+".Value")
+			return
 		}
+		log.Warn().
+			Str("fieldName", name).
+			Str("type", f.Kind().String()).
+			Msg("field marked sensitive but is a struct without a Value field")
+	default:
+		log.Warn().
+			Str("fieldName", name).
+			Str("type", f.Kind().String()).
+			Msg("field marked sensitive but was an unrecognized type")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -79,10 +79,10 @@ type ConfigSource struct {
 }
 
 type SpringConfig struct {
-	Url         StringConfig `json:"url"    yaml:"url"`
+	Url         StringConfig `json:"url"    yaml:"url"    sensitive:"true"`
 	Branch      StringConfig `json:"branch" yaml:"branch"`
-	User        StringConfig `json:"user"   yaml:"user"`
-	Pass        StringConfig `json:"pass"   yaml:"pass"`
+	User        StringConfig `json:"user"   yaml:"user"   sensitive:"true"`
+	Pass        StringConfig `json:"pass"   yaml:"pass"   sensitive:"true"`
 	Description string       `json:"description" yaml:"description"`
 }
 
@@ -94,13 +94,13 @@ type LogConfig struct {
 
 type DbConfig struct {
 	Name            StringConfig `json:"name"            yaml:"name"`
-	Host            StringConfig `json:"host"            yaml:"host"`
+	Host            StringConfig `json:"host"            yaml:"host"            sensitive:"true"`
 	Port            StringConfig `json:"port"            yaml:"port"`
 	Migrate         BoolConfig   `json:"migrate"         yaml:"migrate"`
 	MigrationFolder StringConfig `json:"migrationFolder" yaml:"migrationFolder"`
 	Clean           BoolConfig   `json:"clean"           yaml:"clean"`
-	User            StringConfig `json:"user"            yaml:"user"`
-	Pass            StringConfig `json:"pass"            yaml:"pass"`
+	User            StringConfig `json:"user"            yaml:"user"            sensitive:"true"`
+	Pass            StringConfig `json:"pass"            yaml:"pass"            sensitive:"true"`
 	Pool            DbPoolConfig `json:"pool"            yaml:"pool"`
 	LogLevel        StringConfig `json:"logLevel"        yaml:"logLevel"`
 	Description     string       `json:"description"     yaml:"description"`
@@ -116,10 +116,10 @@ type DbPoolConfig struct {
 }
 
 type QueueConfig struct {
-	Host        StringConfig           `json:"host"        yaml:"host"`
+	Host        StringConfig           `json:"host"        yaml:"host"        sensitive:"true"`
 	Port        StringConfig           `json:"port"        yaml:"port"`
-	User        StringConfig           `json:"user"        yaml:"user"`
-	Pass        StringConfig           `json:"pass"        yaml:"pass"`
+	User        StringConfig           `json:"user"        yaml:"user"        sensitive:"true"`
+	Pass        StringConfig           `json:"pass"        yaml:"pass"        sensitive:"true"`
 	Inventory   InventoryQueueConfig   `json:"inventory"   yaml:"inventory"`
 	Reservation ReservationQueueConfig `json:"reservation" yaml:"reservation"`
 	Product     ProductQueueConfig     `json:"product"     yaml:"product"`


### PR DESCRIPTION
The /env endpoint was mounted outside the auth boundary at the root of the router and rendered the entire Config struct verbatim. The Scrub helper in api/util.go was wired to the response but never had any fields to scrub, because no field in config.Config carried the "sensitive" struct tag — and Scrub itself silently logged a warning ("field marked sensitive but was an unrecognized type") when a struct was tagged because it never recursed into the wrapped *Config types to redact their inner Value field.

Three changes:

- Move /env from the unauthenticated root to /api/v1/admin/env, behind Authenticate and AdminOnly. The old /env path now 404s. Promotes AdminPath/EnvPath to package constants so tests can reference them.
- Tag config.Config password / user / host / url fields with `sensitive:"true"`: Db.Pass, Db.User, Db.Host; RabbitMQ.Pass, RabbitMQ.User, RabbitMQ.Host; Config.Spring.Pass, Config.Spring.User, Config.Spring.Url.
- Refactor api.Scrub: tagged primitive fields are still redacted inline, but a tagged struct field now recurses into a nested Value field (the wrapped *Config types in this project) and redacts that. Untagged structs continue to recurse so nested tags still get hit. Bool case added so future bool fields can be tagged.

Acceptance criteria addressed:
- /env (now /api/v1/admin/env) is gated by Authenticate + AdminOnly.
- TestEnvEndpointRedactsSensitiveValues asserts that none of the configured passwords / users / hosts / urls appear in the response body.
- TestEnvEndpointRequiresAdmin asserts a non-admin authenticated user receives 401.
- TestApiRoutesRequireAuthentication now includes admin/env in its table; the no-credentials and bad-credentials cases both return 401.
- TestOldEnvPathIsGone asserts the unauthenticated /env path returns 404.