### PR TITLE
OPS-001: source-side CI security scanning with SARIF uploads

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,29 +1,31 @@
 name: Lint
 on:
   workflow_call:
-    secrets:
-      webhook:
-        required: true
+permissions:
+  contents: read
+  security-events: write
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          # Tooling Go, not project Go — golangci-lint v1.64 needs >= 1.22.
+          # Project compatibility is tested by test.yml on go.mod's pinned
+          # version. DEP-001 will close the gap.
+          go-version: '1.22'
+          cache: true
+      - name: golangci-lint
+        id: lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          args: --out-format sarif:golangci-lint.sarif,colored-line-number
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('golangci-lint.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: golangci-lint.sarif
+          category: golangci-lint

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,22 @@
+name: Scheduled scans
+# Re-runs every scanner against master once a week so new advisories
+# land in the Security tab without waiting for a PR.
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+  security:
+    uses: ./.github/workflows/sec.yml
+  vuln:
+    uses: ./.github/workflows/vuln.yml
+  secret:
+    uses: ./.github/workflows/secret.yml
+  trivy:
+    uses: ./.github/workflows/trivy.yml

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -1,18 +1,30 @@
 name: Sec
 on:
   workflow_call:
-    secrets:
-      webhook:
-        required: true
+permissions:
+  contents: read
+  security-events: write
 jobs:
-  tests:
+  gosec:
+    name: gosec
     runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
     steps:
-      - name: Checkout Source
-        uses: actions/checkout@v2
-      - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          args: ./...
+          # Tooling Go, not project Go. gosec analyses Go source against
+          # its own ruleset — DEP-001 will move project Go to a newer line.
+          go-version: '1.22'
+          cache: true
+      - name: Run gosec
+        uses: securego/gosec@v2.21.4
+        with:
+          # SARIF for the Security tab; -severity high gates the exit code
+          # so the job fails only on High/Critical findings.
+          args: '-fmt sarif -out gosec.sarif -severity high ./...'
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('gosec.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gosec.sarif
+          category: gosec

--- a/.github/workflows/secret.yml
+++ b/.github/workflows/secret.yml
@@ -1,0 +1,30 @@
+name: Secret
+on:
+  workflow_call:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        # The official action requires a license key for private repos but
+        # works without one on public repos. This repo is public.
+        # Soft-fail until SEC-004 cleans up the known plaintext config in
+        # config.yml / docker-compose.yml; the scanner is here to catch new
+        # secrets from now on.
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: gitleaks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test
 on:
   workflow_call:
-    secrets:
-      webhook:
-        required: true
+permissions:
+  contents: read
 jobs:
   test:
     strategy:
@@ -12,11 +11,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: go test ./...
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,37 @@
+name: Trivy
+on:
+  workflow_call:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  trivy-fs:
+    name: trivy fs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Trivy DB
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            trivy-db-${{ runner.os }}-
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: HIGH,CRITICAL
+          # Surface findings in the Security tab; don't block PRs while
+          # SEC-008's deferred CVEs and the Dockerfile findings are still
+          # open (those clear with DEP-001 and SEC-011).
+          exit-code: '0'
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('trivy-fs.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,16 +3,25 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
+  security-events: write
 jobs:
   lint:
-    uses: sksmith/note-server/.github/workflows/lint.yml@master
+    uses: ./.github/workflows/lint.yml
   security:
-    uses: sksmith/note-server/.github/workflows/sec.yml@master
+    uses: ./.github/workflows/sec.yml
+  vuln:
+    uses: ./.github/workflows/vuln.yml
+  secret:
+    uses: ./.github/workflows/secret.yml
+  trivy:
+    uses: ./.github/workflows/trivy.yml
   test:
-    uses: sksmith/note-server/.github/workflows/test.yml@master
+    uses: ./.github/workflows/test.yml
   notify:
     name: Notification
-    needs: [lint, security, test]
+    needs: [lint, security, vuln, secret, trivy, test]
     runs-on: ubuntu-latest
     steps:
       - uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -1,0 +1,37 @@
+name: Vuln
+on:
+  workflow_call:
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          # Tooling Go, not project Go — govulncheck v1.3 needs >= 1.25.
+          # The vuln scan analyses source statically and works against any
+          # project Go version. DEP-001 will close the gap.
+          go-version: '1.25'
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+      - name: Run govulncheck (SARIF)
+        # SARIF mode emits findings without exiting non-zero, so the upload
+        # step always runs. The Fail step below decides whether the job fails.
+        run: govulncheck -format sarif ./... > govulncheck.sarif
+      - name: Upload SARIF
+        if: ${{ always() && hashFiles('govulncheck.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
+      # Until DEP-001 (Go toolchain) and DEP-002 (chi v4 -> v5) land,
+      # the 25 deferred CVEs from SEC-008 will keep firing here.
+      # Surface them in the Security tab but don't block PRs yet.
+      - name: Run govulncheck (text, soft-fail until DEP-001/DEP-002 land)
+        continue-on-error: true
+        run: govulncheck ./...


### PR DESCRIPTION
## Summary

Closes the source-side half of OPS-001. Every PR now runs golangci-lint,
gosec, govulncheck, gitleaks, and trivy fs, plus the existing go test
matrix, with findings uploaded as SARIF to the GitHub **Security → Code
scanning** tab. A new weekly scheduled workflow re-runs the same scanners
against master so freshly disclosed CVEs land in the Security tab without
needing a PR.

The image-side half (`trivy image`, `syft` SBOM) is split out into the
new [OPS-008](../tree/OPS-001-ci-security-scanning/plan/OPS-008-image-supply-chain-scanning.md),
which depends on [OPS-002](../tree/OPS-001-ci-security-scanning/plan/OPS-002-image-supply-chain.md)
/ [OPS-007](../tree/OPS-001-ci-security-scanning/plan/OPS-007-goreleaser.md) to produce a published image first.

Ticket: [plan/OPS-001-ci-security-scanning.md](../tree/OPS-001-ci-security-scanning/plan/OPS-001-ci-security-scanning.md) (gitignored locally).

## What changed

| File | Change |
| --- | --- |
| [validate.yml](.github/workflows/validate.yml) | Repointed from `sksmith/note-server` reusable workflows to local `./.github/workflows/*`. Now also calls `vuln`, `secret`, `trivy`. |
| [lint.yml](.github/workflows/lint.yml) | golangci-lint v1.29 → v1.64.8, action v2 → v6, SARIF output + upload. Tooling Go pinned to 1.22. |
| [sec.yml](.github/workflows/sec.yml) | gosec `@master` → v2.21.4, SARIF output + upload, `-severity high` gates exit. |
| [test.yml](.github/workflows/test.yml) | Bumped `checkout`/`setup-go` action versions. Module cache enabled. Project Go stays on go.mod's 1.17 until DEP-001. |
| [vuln.yml](.github/workflows/vuln.yml) (new) | govulncheck v1.3.0, SARIF + soft-fail until DEP-001/DEP-002 close SEC-008's 25 deferred CVEs. |
| [trivy.yml](.github/workflows/trivy.yml) (new) | trivy-action v0.28.0 fs scan, HIGH/CRITICAL severity, DB cached. Soft-fail for the same SEC-008 reason and the Dockerfile findings (SEC-011). |
| [secret.yml](.github/workflows/secret.yml) (new) | gitleaks-action v2 over full git history. Soft-fail until SEC-004 cleans the known plaintext config. |
| [scheduled.yml](.github/workflows/scheduled.yml) (new) | Mondays 06:00 UTC + `workflow_dispatch`; fans out to all five scanner workflows. |

## Acceptance criteria

- [x] validate.yml references local workflows, not `sksmith/note-server`.
- [x] govulncheck, gosec, golangci-lint, trivy fs, gitleaks all run on every PR.
- [x] Weekly schedule (Mondays 06:00 UTC).
- [x] SARIF uploaded to Security tab from every scanner via
      `github/codeql-action/upload-sarif@v3`.
- [x] Module / Trivy DB caches in place — should keep wall-clock under
      the 5-minute target on warm runs.

## Notes / scope decisions

- **Soft-fail on three of the five scanners (govulncheck, trivy fs,
  gitleaks).** Hard-failing today would break every PR until the deferred
  findings from SEC-008 / SEC-004 / SEC-011 close. The findings still
  show up in the Security tab — they just don't block. Once those tickets
  land, flip `continue-on-error: true` and `exit-code: '0'` to `false` /
  `1`. I'd rather have visibility now than block delivery while waiting
  for upstream fixes (Go 1.25, chi v5).
- **Tooling Go ≠ project Go.** The new linter and vuln scanners require
  Go 1.22+ / 1.25+; the project Go in `go.mod` is still 1.17. I pinned
  setup-go to a tooling version inline rather than wait for DEP-001;
  test.yml stays on the project's pinned 1.17 so we keep testing what
  we ship.
- **Did NOT add `.golangci.yml` or `gofumpt`** — those are OPS-003.
- **Did NOT bump test.yml's matrix to a newer Go** — DEP-001 owns that.

## Test plan

- [x] `make verify` (fmt, vet, lint, sec, test-race) green locally
- [ ] Open the PR; confirm `lint`, `sec`, `vuln`, `secret`, `trivy`,
      `test` all run as separate jobs under "Validate"
- [ ] Confirm SARIF artifacts upload (Security tab) — the first run on
      master after merge populates the tab
- [ ] Trigger `scheduled.yml` via `workflow_dispatch` post-merge to
      validate the cron path
- [ ] Verify wall-clock < 5 min on a warm run

🤖 Generated with [Claude Code](https://claude.com/claude-code)