### PR TITLE
SEC-003: replace seed admin:admin with env-driven bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,32 @@ RESTful API.
 
 ### Authentication
 
-Many of the endpoints in this project are protected by using a [simple authentication middleware](api/middleware.go). If 
-you're interested in hitting them you can use basic auth admin:admin. Users are stored in the database along with their 
-hashed password. Users are locally cached using [golang-lru](https://github.com/hashicorp/golang-lru). In a production 
-setting if I actually wanted caching I'd either use a remote cache like Redis, or a distributed local cache like 
-groupcache to prevent stale or out of sync data.
+Many of the endpoints in this project are protected by using a [simple authentication middleware](api/middleware.go).
+Users are stored in the database with bcrypt-hashed passwords and locally cached using
+[golang-lru](https://github.com/hashicorp/golang-lru). In a production setting if I actually wanted caching I'd either
+use a remote cache like Redis, or a distributed local cache like groupcache to prevent stale or out of sync data.
+
+#### Bootstrap admin
+
+On startup the application ensures an `admin` user exists. Behavior depends on the running profile:
+
+- **`local` / `dev` (default):** if no admin exists, one is created. If `BOOTSTRAP_ADMIN_PASSWORD` is set, that
+  password is used; otherwise a 32-character random password is generated and printed to the log **once** with a
+  warning. Capture it on first run — it will not be shown again.
+- **`prod`:** the application refuses to start if no admin exists and `BOOTSTRAP_ADMIN_PASSWORD` is unset. Set the
+  env var (typically via your secret manager) and start.
+
+Older databases that ran the seed `admin:admin` migration are detected and replaced on startup. Newly-created
+databases never carry the seed credential.
+
+```sh
+# local: pick your own password
+BOOTSTRAP_ADMIN_PASSWORD=please-change-me go run ./cmd
+
+# local: let it generate one and watch the logs
+go run ./cmd
+# {"level":"warn","username":"admin","password":"<base64 token>","message":"bootstrap admin user created with auto-generated password..."}
+```
 
 ### Metrics
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,10 @@ func main() {
 
 	userService := user.NewService(ur)
 
+	if err := user.Bootstrap(ctx, ur, cfg.Profile.Value, os.Getenv("BOOTSTRAP_ADMIN_PASSWORD")); err != nil {
+		log.Fatal().Err(err).Msg("admin bootstrap failed")
+	}
+
 	r := api.ConfigureRouter(cfg, invService, invService, userService)
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)

--- a/core/user/bootstrap.go
+++ b/core/user/bootstrap.go
@@ -1,0 +1,117 @@
+package user
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/sksmith/go-micro-example/core"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	// AdminUsername is the username of the bootstrap admin account. It is
+	// created on first startup if missing.
+	AdminUsername = "admin"
+
+	// SeedAdminHash is the bcrypt of the legacy "admin" password that the
+	// 000002 migration used to insert. Any DB still carrying this exact
+	// hash is treated as if no admin exists, so the bootstrap path runs.
+	SeedAdminHash = "$2a$10$v6K6OZgz.oUPSPGQfiarAOzD6JTz2.e5hdKCkq31NglPnAsT6j1GO"
+
+	profileProd = "prod"
+)
+
+// ErrAdminPasswordRequired is returned when running in a profile that
+// refuses to auto-generate a password and no BOOTSTRAP_ADMIN_PASSWORD
+// has been supplied.
+var ErrAdminPasswordRequired = errors.New("admin user is missing and BOOTSTRAP_ADMIN_PASSWORD was not supplied; refusing to start")
+
+// Bootstrap ensures an admin user exists. It implements the SEC-003
+// flow:
+//
+//   - If the admin user is missing (or still carries the legacy seed
+//     hash), create or replace it with bootstrapPassword.
+//   - If bootstrapPassword is empty and profile is "prod", return
+//     ErrAdminPasswordRequired.
+//   - If bootstrapPassword is empty and profile is non-prod, generate
+//     a random password and emit it to the log exactly once with a
+//     loud warning so the operator can capture it.
+//
+// It is safe to call on every startup. It is a no-op when an admin
+// already exists with a non-seed password.
+func Bootstrap(ctx context.Context, repo Repository, profile, bootstrapPassword string) error {
+	existing, getErr := repo.Get(ctx, AdminUsername)
+	hasSeedAdmin := getErr == nil && existing.HashedPassword == SeedAdminHash
+	switch {
+	case errors.Is(getErr, core.ErrNotFound):
+		// fall through; create below
+	case getErr != nil:
+		return errors.WithStack(getErr)
+	case hasSeedAdmin:
+		log.Warn().Str("username", AdminUsername).Msg("seed admin password detected; replacing")
+	default:
+		log.Debug().Str("username", AdminUsername).Msg("admin user already present, skipping bootstrap")
+		return nil
+	}
+
+	password, generated, err := resolveBootstrapPassword(profile, bootstrapPassword)
+	if err != nil {
+		return err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if hasSeedAdmin {
+		if err := repo.Delete(ctx, AdminUsername); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	u := &User{
+		Username:       AdminUsername,
+		HashedPassword: string(hash),
+		IsAdmin:        true,
+	}
+	if err := repo.Create(ctx, u); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if generated {
+		log.Warn().
+			Str("username", AdminUsername).
+			Str("password", password).
+			Msg("bootstrap admin user created with auto-generated password; capture this now — it will not be shown again")
+	} else {
+		log.Info().Str("username", AdminUsername).Msg("bootstrap admin user created from BOOTSTRAP_ADMIN_PASSWORD")
+	}
+	return nil
+}
+
+func resolveBootstrapPassword(profile, supplied string) (password string, generated bool, err error) {
+	if supplied != "" {
+		return supplied, false, nil
+	}
+	if profile == profileProd {
+		return "", false, ErrAdminPasswordRequired
+	}
+	gen, err := generatePassword()
+	if err != nil {
+		return "", false, errors.WithStack(err)
+	}
+	return gen, true, nil
+}
+
+func generatePassword() (string, error) {
+	const bytes = 24
+	buf := make([]byte, bytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/core/user/bootstrap_test.go
+++ b/core/user/bootstrap_test.go
@@ -1,0 +1,154 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/core"
+	"github.com/sksmith/go-micro-example/core/user"
+	"github.com/sksmith/go-micro-example/db/usrrepo"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestBootstrap(t *testing.T) {
+	t.Run("creates admin from supplied password when missing", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{}, core.ErrNotFound
+		}
+		var created *user.User
+		repo.CreateFunc = func(ctx context.Context, u *user.User, _ ...core.UpdateOptions) error {
+			created = u
+			return nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "local", "supplied-password")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if created == nil {
+			t.Fatal("expected user to be created")
+		}
+		if created.Username != user.AdminUsername {
+			t.Errorf("expected username %q, got %q", user.AdminUsername, created.Username)
+		}
+		if !created.IsAdmin {
+			t.Error("expected IsAdmin true")
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(created.HashedPassword), []byte("supplied-password")); err != nil {
+			t.Errorf("hashed password did not match supplied: %v", err)
+		}
+	})
+
+	t.Run("non-prod profile generates a random password when none supplied", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{}, core.ErrNotFound
+		}
+		var created *user.User
+		repo.CreateFunc = func(ctx context.Context, u *user.User, _ ...core.UpdateOptions) error {
+			created = u
+			return nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "local", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if created == nil {
+			t.Fatal("expected user to be created")
+		}
+		// The generated password is the bcrypt input, not the hash. We
+		// can't recover it here, but we can confirm a hash was set.
+		if !strings.HasPrefix(created.HashedPassword, "$2") {
+			t.Errorf("expected bcrypt hash, got %q", created.HashedPassword)
+		}
+	})
+
+	t.Run("prod profile fails fast when no password supplied", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{}, core.ErrNotFound
+		}
+		createCalled := false
+		repo.CreateFunc = func(ctx context.Context, u *user.User, _ ...core.UpdateOptions) error {
+			createCalled = true
+			return nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "prod", "")
+		if !errors.Is(err, user.ErrAdminPasswordRequired) {
+			t.Fatalf("expected ErrAdminPasswordRequired, got %v", err)
+		}
+		if createCalled {
+			t.Error("expected no user creation when prod bootstrap fails")
+		}
+	})
+
+	t.Run("no-op when admin already exists with non-seed password", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{Username: user.AdminUsername, HashedPassword: "$2a$10$realProductionHash", IsAdmin: true}, nil
+		}
+		createCalled := false
+		repo.CreateFunc = func(ctx context.Context, u *user.User, _ ...core.UpdateOptions) error {
+			createCalled = true
+			return nil
+		}
+		deleteCalled := false
+		repo.DeleteFunc = func(ctx context.Context, username string, _ ...core.UpdateOptions) error {
+			deleteCalled = true
+			return nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "prod", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if createCalled || deleteCalled {
+			t.Error("expected no Create or Delete when admin already exists with non-seed password")
+		}
+	})
+
+	t.Run("replaces seed admin even in prod when password supplied", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{Username: user.AdminUsername, HashedPassword: user.SeedAdminHash, IsAdmin: true}, nil
+		}
+		deleted := false
+		repo.DeleteFunc = func(ctx context.Context, username string, _ ...core.UpdateOptions) error {
+			deleted = true
+			return nil
+		}
+		var created *user.User
+		repo.CreateFunc = func(ctx context.Context, u *user.User, _ ...core.UpdateOptions) error {
+			created = u
+			return nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "prod", "rotated-pw")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !deleted {
+			t.Error("expected seed admin to be deleted before re-creation")
+		}
+		if created == nil || bcrypt.CompareHashAndPassword([]byte(created.HashedPassword), []byte("rotated-pw")) != nil {
+			t.Errorf("expected new admin with rotated password, got %+v", created)
+		}
+	})
+
+	t.Run("prod fails fast on seed admin without supplied password", func(t *testing.T) {
+		repo := usrrepo.NewMockRepo()
+		repo.GetFunc = func(ctx context.Context, username string, _ ...core.QueryOptions) (user.User, error) {
+			return user.User{Username: user.AdminUsername, HashedPassword: user.SeedAdminHash, IsAdmin: true}, nil
+		}
+
+		err := user.Bootstrap(context.Background(), repo, "prod", "")
+		if !errors.Is(err, user.ErrAdminPasswordRequired) {
+			t.Fatalf("expected ErrAdminPasswordRequired, got %v", err)
+		}
+	})
+}

--- a/db/migrations/000002_create_users_table.up.sql
+++ b/db/migrations/000002_create_users_table.up.sql
@@ -6,7 +6,4 @@ CREATE TABLE users
     created_at  TIMESTAMP WITH TIME ZONE
 );
 
-INSERT INTO users (username, password, is_admin, created_at)
-    VALUES ('admin', '$2a$10$v6K6OZgz.oUPSPGQfiarAOzD6JTz2.e5hdKCkq31NglPnAsT6j1GO', true, NOW());
-
 COMMIT;


### PR DESCRIPTION
## Summary

Removes the `admin:admin` default that was both seeded by the 000002
migration and documented in the README. Replaces it with a startup
bootstrap that reads `BOOTSTRAP_ADMIN_PASSWORD`, generates a random
password (with a loud one-shot log warning) in non-prod profiles, and
fails fast in `prod` if neither an admin user nor the env var is
present.

The seed `INSERT` is also removed from the migration so newly created
databases never carry it. Existing databases that ran the old
migration are detected via the well-known bcrypt hash and rotated on
the same code path — including a fail-fast on prod startup if the
operator forgot to set the env var.

Ticket: [plan/SEC-003-default-admin-credentials.md](../tree/SEC-003-default-admin-credentials/plan/SEC-003-default-admin-credentials.md) (gitignored locally).

## Acceptance criteria

- [x] Default admin credentials are not present in any default
      migration shipped to non-dev environments — seed `INSERT` removed
      from `db/migrations/000002_create_users_table.up.sql`.
- [x] Bootstrap admin password is supplied via secret
      (`BOOTSTRAP_ADMIN_PASSWORD`) at startup, randomly generated in
      `local` / `dev` profiles and emitted to logs **once** with a
      loud warning if missing.
- [x] Startup fails fast in `prod` profile if no admin secret is
      supplied and no admin user exists — `user.ErrAdminPasswordRequired`.
- [x] README updated to reflect the new flow (section: \"Bootstrap admin\").

## Notes / scope decisions

- **Detection of the legacy seed hash.** Any DB still carrying the exact
  bcrypt of \"admin\" from the old migration is treated as \"no admin
  exists\" so the bootstrap path runs. This catches operators who
  migrated up months ago and never rotated. In `prod`, that means a
  service that previously started cleanly will now refuse to start
  until `BOOTSTRAP_ADMIN_PASSWORD` is set — that is the desired
  behaviour for SEC-003. Document accordingly when releasing.
- **Random password format.** 24 random bytes, base64-RawURL-encoded.
  ~32 ASCII characters, copy-pasteable, alphabet-safe. Logged at WARN
  level once.
- **No new dependencies.** Uses `crypto/rand` and `golang.org/x/crypto/bcrypt`
  (already vendored).
- **Bootstrap lives in `core/user/bootstrap.go`** rather than
  `cmd/main.go` so it is unit-testable against the existing
  `usrrepo.MockRepo`.
- **Did NOT touch the auth flow itself.** That is SEC-002.

## Test plan

- [x] `make verify` (fmt, vet, lint, sec, test-race) green
- [x] `TestBootstrap` covers six branches: missing+supplied,
      missing+generated, missing+prod-fails, exists+noop,
      seed+rotated, seed+prod-fails
- [ ] Manual: `BOOTSTRAP_ADMIN_PASSWORD=please-rotate go run ./cmd`
      against a fresh local Postgres → admin user created with that
      password
- [ ] Manual: same as above with no env var on `local` profile → log
      shows the generated password exactly once
- [ ] Manual: `-p prod` with no env var and empty users table → fatal
      with `ErrAdminPasswordRequired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)