### PR TITLE
SEC-004: move credentials out of tracked files into env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy to .env and fill in. .env is gitignored.
+#
+# Application credentials (consumed by the Go app via viper):
+GME_DB_USER=postgres
+GME_DB_PASS=postgres
+GME_RABBITMQ_USER=guest
+GME_RABBITMQ_PASS=guest
+
+# Bootstrap admin (consumed once at startup; SEC-003):
+BOOTSTRAP_ADMIN_PASSWORD=please-change-me
+
+# docker-compose overrides. These ONLY affect how the dev stack containers
+# initialise themselves; the Go app reads the GME_* vars above.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=go-micro-example-db
+PGADMIN_DEFAULT_EMAIL=admin@example.com
+PGADMIN_DEFAULT_PASSWORD=admin
+RABBITMQ_DEFAULT_USER=guest
+RABBITMQ_DEFAULT_PASS=guest

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ vendor/
 
 # IDE Configurations
 .idea
+
+# Local review/planning artifacts
+plan/
+
+# Local secrets / config overrides (SEC-004)
+.env
+.env.local
+config.local.yml
+

--- a/README.md
+++ b/README.md
@@ -104,7 +104,40 @@ their benchmarks look really great too! You can get structured logging or nice h
 
 ### Configuration
 
-This project uses [viper](https://github.com/spf13/viper) for handling externalized configurations. At the moment it only reads from the local config.yml but the plan is to make it compatible with [Spring Cloud Config](https://cloud.spring.io/spring-cloud-config), and [etcd](https://etcd.io).
+This project uses [viper](https://github.com/spf13/viper) for handling externalized configurations. At the moment it
+only reads from the local config.yml but the plan is to make it compatible with
+[Spring Cloud Config](https://cloud.spring.io/spring-cloud-config), and [etcd](https://etcd.io).
+
+#### Secrets and credentials
+
+Credentials never live in tracked files. The four sensitive viper keys — `db.user`, `db.pass`, `rabbitmq.user`,
+`rabbitmq.pass` — are blank in `config.yml` and read from env vars at startup. Names are upper-snake with the `GME_`
+prefix:
+
+| viper key | env var |
+| --- | --- |
+| `db.user` | `GME_DB_USER` |
+| `db.pass` | `GME_DB_PASS` |
+| `rabbitmq.user` | `GME_RABBITMQ_USER` |
+| `rabbitmq.pass` | `GME_RABBITMQ_PASS` |
+
+Additionally, `BOOTSTRAP_ADMIN_PASSWORD` (no prefix) seeds the admin user — see [Bootstrap admin](#bootstrap-admin).
+
+Three convenient ways to supply these locally:
+
+1. **Inline:** `GME_DB_PASS=postgres go run ./cmd`
+2. **`.env` file** in the repo root (gitignored). Sourced manually (`set -a; source .env; set +a`) or via tools like
+   `direnv`. See [.env.example](.env.example) for the shape.
+3. **`config.local.yml`** in the repo root (gitignored). Same schema as `config.yml`; merged on top at startup.
+
+In production, populate the env vars from your secret manager (Vault, AWS Secrets Manager, GCP Secret Manager) — see
+DSN-006 in the local plan/.
+
+#### Local stack credentials
+
+[docker-compose.yml](docker-compose.yml) parameterises the Postgres / pgAdmin / RabbitMQ admin credentials with the
+`${VAR:-default}` pattern, so the literal passwords no longer live in tracked YAML. Defaults remain dev-friendly
+(`postgres`, `guest`, `admin`) so `docker-compose up -d` still works out of the box for new contributors.
 
 ### Testing
 

--- a/config.yml
+++ b/config.yml
@@ -13,8 +13,8 @@ db:
   name: go-micro-example-db
   host: localhost
   port: 5432
-  user: postgres
-  pass: postgres
+  # user / pass intentionally unset; supply via env vars
+  # GME_DB_USER and GME_DB_PASS or via config.local.yml (gitignored).
   clean: false
   logLevel: warn
   pool:
@@ -24,8 +24,8 @@ db:
 rabbitmq:
   host: localhost
   port: 5672
-  user: guest
-  pass: guest
+  # user / pass intentionally unset; supply via env vars
+  # GME_RABBITMQ_USER and GME_RABBITMQ_PASS or via config.local.yml.
   inventory:
     exchange: inventory.exchange
   reservation:

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -193,6 +194,27 @@ func init() {
 	viper.SetDefault("rabbitmq.reservation.exchange", def.RabbitMQ.Reservation.Exchange.Default)
 	viper.SetDefault("rabbitmq.product.queue", def.RabbitMQ.Product.Queue.Default)
 	viper.SetDefault("rabbitmq.product.dlt.exchange", def.RabbitMQ.Product.Dlt.Exchange.Default)
+
+	bindSensitiveEnv()
+}
+
+// bindSensitiveEnv wires the credential-bearing config keys to env-var
+// fallbacks so secrets can stay out of tracked files (SEC-004). Env vars
+// use the GME_ prefix and replace dotted keys with underscores —
+// `db.pass` becomes `GME_DB_PASS`, etc.
+func bindSensitiveEnv() {
+	viper.SetEnvPrefix("GME")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	for _, key := range []string{
+		"db.user",
+		"db.pass",
+		"rabbitmq.user",
+		"rabbitmq.pass",
+	} {
+		// Errors here would mean a programming error in the key list —
+		// viper.BindEnv only fails on empty input.
+		_ = viper.BindEnv(key)
+	}
 }
 
 func LoadDefaults() *Config {
@@ -241,6 +263,19 @@ func loadLocalConfigs(filename string, config *Config) error {
 	err := viper.ReadInConfig()
 	if err != nil {
 		return err
+	}
+
+	// Merge an optional gitignored config.local.yml on top of the base
+	// file so a developer can keep their own GME_* credentials out of
+	// the env if they prefer (SEC-004).
+	viper.SetConfigName(filename + ".local")
+	if mergeErr := viper.MergeInConfig(); mergeErr != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(mergeErr, &notFound) {
+			return mergeErr
+		}
+	} else {
+		log.Info().Str("file", filename+".local").Msg("merged local override file")
 	}
 
 	err = viper.Unmarshal(config, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
@@ -469,8 +504,8 @@ func setupDefaults(config *Config) {
 	config.Db.Migrate = BoolConfig{Value: true, Default: true, Description: "Whether or not database migrations should be executed on startup."}
 	config.Db.MigrationFolder = StringConfig{Value: "db/migrations", Default: "db/migrations", Description: "Location of migration files to be executed on startup."}
 	config.Db.Clean = BoolConfig{Value: false, Default: false, Description: "WARNING: THIS WILL DELETE ALL DATA FROM THE DB. Used only during migration. If clean is true, all 'down' migrations are executed."}
-	config.Db.User = StringConfig{Value: "postgres", Default: "postgres", Description: "User the application will use to connect to the database."}
-	config.Db.Pass = StringConfig{Value: "postgres", Default: "postgres", Description: "Password the application will use for connecting to the database."}
+	config.Db.User = StringConfig{Value: "", Default: "", Description: "User the application will use to connect to the database. Supply via GME_DB_USER."}
+	config.Db.Pass = StringConfig{Value: "", Default: "", Description: "Password the application will use for connecting to the database. Supply via GME_DB_PASS."}
 	config.Db.Pool.MinSize = IntConfig{Value: 1, Default: 1, Description: "The minimum size of the pool."}
 	config.Db.Pool.MaxSize = IntConfig{Value: 3, Default: 3, Description: "The maximum size of the pool."}
 	config.Db.Pool.MaxConnLife = IntConfig{Value: time.Hour.Milliseconds(), Default: time.Hour.Milliseconds(), Description: "The maximum time a connection can live in the pool in milliseconds."}
@@ -480,8 +515,8 @@ func setupDefaults(config *Config) {
 	config.RabbitMQ.Description = "Rabbit MQ congfigurations."
 	config.RabbitMQ.Host = StringConfig{Value: "localhost", Default: "localhost", Description: "RabbitMQ's broker host."}
 	config.RabbitMQ.Port = StringConfig{Value: "5432", Default: "5432", Description: "RabbitMQ's broker host port."}
-	config.RabbitMQ.User = StringConfig{Value: "guest", Default: "guest", Description: "User the application will use to connect to RabbitMQ."}
-	config.RabbitMQ.Pass = StringConfig{Value: "guest", Default: "guest", Description: "Password the application will use to connect to RabbitMQ."}
+	config.RabbitMQ.User = StringConfig{Value: "", Default: "", Description: "User the application will use to connect to RabbitMQ. Supply via GME_RABBITMQ_USER."}
+	config.RabbitMQ.Pass = StringConfig{Value: "", Default: "", Description: "Password the application will use to connect to RabbitMQ. Supply via GME_RABBITMQ_PASS."}
 
 	config.RabbitMQ.Inventory.Description = "RabbitMQ settings for inventory related updates."
 	config.RabbitMQ.Inventory.Exchange = StringConfig{Value: "inventory.exchange", Default: "inventory.exchange", Description: "RabbitMQ exchang}}e to use for posting inventory updates."}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,3 +28,43 @@ func TestLoad(t *testing.T) {
 		t.Errorf("profile got=%s want=%s", cfg.Profile.Value, "test")
 	}
 }
+
+func TestSensitiveCredentialsLoadFromEnv(t *testing.T) {
+	tests := []struct {
+		envKey string
+		want   string
+		got    func(*config.Config) string
+	}{
+		{"GME_DB_USER", "env-db-user", func(c *config.Config) string { return c.Db.User.Value }},
+		{"GME_DB_PASS", "env-db-pass", func(c *config.Config) string { return c.Db.Pass.Value }},
+		{"GME_RABBITMQ_USER", "env-mq-user", func(c *config.Config) string { return c.RabbitMQ.User.Value }},
+		{"GME_RABBITMQ_PASS", "env-mq-pass", func(c *config.Config) string { return c.RabbitMQ.Pass.Value }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.envKey, func(t *testing.T) {
+			t.Setenv(tc.envKey, tc.want)
+			cfg := config.Load("config_test")
+			if got := tc.got(cfg); got != tc.want {
+				t.Errorf("%s: got=%q want=%q", tc.envKey, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSensitiveCredentialsHaveNoBakedDefaults(t *testing.T) {
+	cfg := config.LoadDefaults()
+	for _, tc := range []struct {
+		name string
+		val  string
+	}{
+		{"Db.User", cfg.Db.User.Default},
+		{"Db.Pass", cfg.Db.Pass.Default},
+		{"RabbitMQ.User", cfg.RabbitMQ.User.Default},
+		{"RabbitMQ.Pass", cfg.RabbitMQ.Pass.Default},
+	} {
+		if tc.val != "" {
+			t.Errorf("%s.Default leaked %q; expected empty so the only source is env / config.local.yml", tc.name, tc.val)
+		}
+	}
+}

--- a/config_test.yml
+++ b/config_test.yml
@@ -13,8 +13,7 @@ db:
   name: go-micro-example-db
   host: localhost
   port: 5432
-  user: postgres
-  pass: postgres
+  # user / pass: integration tests must supply GME_DB_USER, GME_DB_PASS.
   migrate: true
   migrationFolder: ../db/migrations
   clean: true
@@ -26,8 +25,7 @@ db:
 rabbitmq:
   host: localhost
   port: 5672
-  user: guest
-  pass: guest
+  # user / pass: integration tests must supply GME_RABBITMQ_USER, GME_RABBITMQ_PASS.
   inventory:
     exchange: inventory.exchange
   reservation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 version: '3'
+# Local-development stack only. Credentials default to dev values for
+# convenience but accept overrides via env vars (or a gitignored .env
+# file in this directory). Do not run this compose file in production.
 services:
   postgres:
     image: postgres
@@ -6,9 +9,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: go-micro-example-db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-go-micro-example-db}
 
   pgadmin:
     image: dpage/pgadmin4
@@ -17,8 +20,8 @@ services:
     ports:
       - "9090:80"
     environment:
-      PGADMIN_DEFAULT_EMAIL: oz@oz.com
-      PGADMIN_DEFAULT_PASSWORD: oz
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
 
   rabbitmq:
     image: rabbitmq:3.9-management-alpine
@@ -26,3 +29,6 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-guest}


### PR DESCRIPTION
## Summary

Strips the plaintext credentials that lived in `config.yml`,
`config_test.yml`, and `docker-compose.yml`, plus the matching
`"postgres"` / `"guest"` defaults baked into Go code. Replaces them
with a viper env-var binding (`GME_*` prefix), an optional gitignored
`config.local.yml` override, and `${VAR:-default}` indirection in
docker-compose. Defaults still resolve to the dev-friendly values so
`docker-compose up -d` keeps working for new contributors, but the
literals no longer live in tracked YAML.

The four sensitive keys:

| viper key | env var |
| --- | --- |
| `db.user` | `GME_DB_USER` |
| `db.pass` | `GME_DB_PASS` |
| `rabbitmq.user` | `GME_RABBITMQ_USER` |
| `rabbitmq.pass` | `GME_RABBITMQ_PASS` |

Ticket: [plan/SEC-004-secrets-management.md](../tree/SEC-004-secrets-management/plan/SEC-004-secrets-management.md) (gitignored locally).

## Acceptance criteria

- [x] No production secrets in tracked files. The four `db` /
      `rabbitmq` credentials are blank in config.yml and the in-code
      defaults; docker-compose passwords are `${VAR:-default}`.
- [x] `config.yml` ships only non-sensitive defaults; secrets read
      from env vars or a gitignored `config.local.yml`.
- [ ] The runtime image does not contain `config.yml` with prod
      values; config is mounted or pulled at startup. **Partially:**
      after this change `config.yml` has no prod values to leak, but
      it is still `COPY`'d into the image. Tightening that to "no
      config in the image" interacts with the release pipeline and
      is deferred to **OPS-002** / **OPS-007**.
- [x] Pre-commit hook or CI step (e.g. gitleaks) prevents future
      secret commits — **CI:** gitleaks landed in OPS-001 and is
      already running on every PR; **pre-commit:** OPS-003's job.

## What changed

- [config.yml](config.yml): `db.user`/`db.pass`/`rabbitmq.user`/`rabbitmq.pass`
  removed; comments point at the env vars.
- [config_test.yml](config_test.yml): same four keys stripped so
  integration tests have to source env vars explicitly.
- [config/config.go](config/config.go): defaults for those four keys
  set to `""`; new `bindSensitiveEnv()` wires `GME_` prefix +
  `BindEnv` calls; `loadLocalConfigs` now `MergeInConfig`'s an
  optional `config.local.yml`.
- [docker-compose.yml](docker-compose.yml): all three services use
  `${VAR:-default}` for credentials.
- [.env.example](.env.example) (new): documents every env var.
- [.gitignore](.gitignore): adds `.env`, `.env.local`,
  `config.local.yml`.
- [README.md](README.md): new "Secrets and credentials" subsection
  under Configuration documents the three local-supply options
  (inline, `.env`, `config.local.yml`) plus the prod path.
- [config/config_test.go](config/config_test.go):
  `TestSensitiveCredentialsLoadFromEnv` (table) and
  `TestSensitiveCredentialsHaveNoBakedDefaults` (invariant guard).

## Notes / scope decisions

- **Dockerfile still COPYs config.yml.** It's not a leak after this
  change — the file has no secrets — but a strict "no config in the
  image" policy ties into the release pipeline and is left for
  OPS-002 / OPS-007.
- **GME_ prefix vs no prefix.** Picked `GME_` for viper-bound keys
  because viper's prefix support is per-instance and keeps the env
  surface scoped. `BOOTSTRAP_ADMIN_PASSWORD` (SEC-003) stays
  unprefixed because it isn't a viper key — it's read directly via
  `os.Getenv`. Both documented in the README.
- **Did NOT clear defaults for `db.host`, `rabbitmq.host`.** They are
  tagged sensitive (SEC-013) but are not credentials and `localhost`
  is a fine default for dev.
- **Did NOT add a pre-commit hook.** That belongs to OPS-003.
- **Did NOT integrate Vault.** That is DSN-006.

## Test plan

- [x] `make verify` (fmt, vet, lint, sec, test-race) green
- [x] `TestSensitiveCredentialsLoadFromEnv` — env vars override config
- [x] `TestSensitiveCredentialsHaveNoBakedDefaults` — pins the
      empty-string invariant
- [ ] Manual: `docker-compose up -d` still spins up cleanly with
      defaults
- [ ] Manual: `GME_DB_PASS=foo go run ./cmd` against fresh Postgres,
      confirm connection works
- [ ] Manual: `cp config.yml config.local.yml`, set creds inline,
      confirm merge happens (log line: "merged local override file")

🤖 Generated with [Claude Code](https://claude.com/claude-code)