### PR TITLE
SEC-002b: counter metrics for Basic Auth and JWT requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ This application outputs prometheus metrics using middleware I plugged into the 
 locally check them out at [http://localhost:8080/metrics](http://localhost:8080/metrics). Every URL automatically
 gets a hit count and a latency metric added. You can find the configurations [here](api/middleware.go).
 
+In addition to the per-URL metrics, the auth middleware exposes two counters so you can track the
+SEC-002 migration from Basic Auth to JWTs:
+
+| Metric | Meaning |
+| --- | --- |
+| `auth_basic_requests_total` | Successful HTTP Basic Auth requests. |
+| `auth_jwt_requests_total` | Successful Bearer JWT requests. |
+
+Neither counter increments on auth failure. SEC-002c will remove the Basic Auth path once
+`rate(auth_basic_requests_total[1d])` is at zero across at least one release cycle.
+
 ### Logging
 
 I ended up going with [zerolog](https://github.com/rs/zerolog) for logging in this project. I really like its API and 

--- a/api/auth_metrics_test.go
+++ b/api/auth_metrics_test.go
@@ -1,0 +1,109 @@
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/api"
+	"github.com/sksmith/go-micro-example/core"
+	"github.com/sksmith/go-micro-example/core/user"
+)
+
+// readCounter scrapes /metrics and returns the value of the named
+// Prometheus counter. Returns -1 when the counter is absent so a test
+// can distinguish missing from zero.
+func readCounter(t *testing.T, ts *httptest.Server, name string) float64 {
+	t.Helper()
+	res, err := http.Get(ts.URL + api.MetricsEndpoint)
+	if err != nil {
+		t.Fatalf("scrape /metrics: %v", err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read /metrics: %v", err)
+	}
+	prefix := name + " "
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			// Prometheus text format: "<name> <value>"
+			value := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			v, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				t.Fatalf("parse counter line %q: %v", line, err)
+			}
+			return v
+		}
+	}
+	return -1
+}
+
+func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
+	r, usrSvc, signer := newTestRouterWithSigner()
+	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
+		if username == "alice" && password == "pw" {
+			return user.User{Username: "alice", IsAdmin: true}, nil
+		}
+		return user.User{}, core.ErrNotFound
+	}
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	basicBefore := readCounter(t, ts, "auth_basic_requests_total")
+	jwtBefore := readCounter(t, ts, "auth_jwt_requests_total")
+	if basicBefore < 0 || jwtBefore < 0 {
+		t.Fatalf("expected counters to exist, basic=%v jwt=%v", basicBefore, jwtBefore)
+	}
+
+	// Successful Basic Auth → basic counter should advance, jwt should not.
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
+	req.SetBasicAuth("alice", "pw")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+
+	// Failed Basic Auth → no counter movement.
+	req2, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
+	req2.SetBasicAuth("alice", "wrong")
+	res2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res2.Body.Close()
+
+	// Successful Bearer → jwt counter should advance, basic should not.
+	tok, _, _ := signer.Issue(user.User{Username: "alice", IsAdmin: true})
+	req3, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
+	req3.Header.Set("Authorization", "Bearer "+tok)
+	res3, err := http.DefaultClient.Do(req3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res3.Body.Close()
+
+	// Failed Bearer → no counter movement.
+	req4, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
+	req4.Header.Set("Authorization", "Bearer not-a-real-token")
+	res4, err := http.DefaultClient.Do(req4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res4.Body.Close()
+
+	basicAfter := readCounter(t, ts, "auth_basic_requests_total")
+	jwtAfter := readCounter(t, ts, "auth_jwt_requests_total")
+
+	if basicAfter-basicBefore != 1 {
+		t.Errorf("auth_basic_requests_total moved by %v, want 1", basicAfter-basicBefore)
+	}
+	if jwtAfter-jwtBefore != 1 {
+		t.Errorf("auth_jwt_requests_total moved by %v, want 1", jwtAfter-jwtBefore)
+	}
+}

--- a/api/authapi_test.go
+++ b/api/authapi_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/sksmith/go-micro-example/api"
@@ -128,10 +129,18 @@ func TestProtectedRouteAcceptsBearerJWT(t *testing.T) {
 func TestProtectedRouteRejectsTamperedBearer(t *testing.T) {
 	r, _, signer := newTestRouterWithSigner()
 	tok, _, _ := signer.Issue(user.User{Username: "alice"})
-	tampered := tok[:len(tok)-1] + "A"
-	if tampered == tok {
-		tampered = tok[:len(tok)-1] + "B"
+	// Tamper a byte inside the signature segment (not at the
+	// base64-url padding boundary, where flipping a char can decode
+	// to the same signature byte).
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("malformed token: %s", tok)
 	}
+	swap := byte('A')
+	if parts[2][0] == 'A' {
+		swap = 'B'
+	}
+	tampered := parts[0] + "." + parts[1] + "." + string(swap) + parts[2][1:]
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -73,6 +73,10 @@ type UserAccess interface {
 // is never tried as Basic, even if the JWT is malformed — so a typo'd
 // JWT does not silently degrade to a 401-from-missing-Basic-creds.
 func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Handler {
+	// Ensure the auth counters exist even if Metrics() never runs first
+	// (defensive — in normal wiring Metrics() is registered before
+	// Authenticate, but tests sometimes mount Authenticate alone).
+	metricsOnce.Do(initMetrics)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
@@ -84,6 +88,7 @@ func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Ha
 					authErr(w)
 					return
 				}
+				authJWTCounter.Inc()
 				ctx := context.WithValue(r.Context(), CtxKeyUser, u)
 				next.ServeHTTP(w, r.WithContext(ctx))
 			default:
@@ -102,6 +107,7 @@ func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Ha
 					}
 					return
 				}
+				authBasicCounter.Inc()
 				ctx := context.WithValue(r.Context(), CtxKeyUser, u)
 				next.ServeHTTP(w, r.WithContext(ctx))
 			}
@@ -166,9 +172,11 @@ func Logging(next http.Handler) http.Handler {
 }
 
 var (
-	metricsOnce sync.Once
-	urlHitCount *prometheus.CounterVec
-	urlLatency  *prometheus.SummaryVec
+	metricsOnce      sync.Once
+	urlHitCount      *prometheus.CounterVec
+	urlLatency       *prometheus.SummaryVec
+	authBasicCounter prometheus.Counter
+	authJWTCounter   prometheus.Counter
 )
 
 func initMetrics() {
@@ -188,8 +196,19 @@ func initMetrics() {
 		[]string{"method", "url"},
 	)
 
+	authBasicCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "auth_basic_requests_total",
+		Help: "Number of requests authenticated via HTTP Basic Auth. Tracked per SEC-002b so SEC-002c can remove the Basic Auth path when this rate drops to zero.",
+	})
+	authJWTCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "auth_jwt_requests_total",
+		Help: "Number of requests authenticated via Bearer JWT.",
+	})
+
 	prometheus.MustRegister(urlHitCount)
 	prometheus.MustRegister(urlLatency)
+	prometheus.MustRegister(authBasicCounter)
+	prometheus.MustRegister(authJWTCounter)
 }
 
 func Metrics(next http.Handler) http.Handler {

--- a/core/auth/jwt_test.go
+++ b/core/auth/jwt_test.go
@@ -106,18 +106,21 @@ func TestParseRejectsExpired(t *testing.T) {
 func TestParseRejectsTampered(t *testing.T) {
 	s, _ := auth.NewSigner([]byte(validKey), 0, true)
 	tok, _, _ := s.Issue(user.User{Username: "alice"})
-	// flip the last character of the signature segment
 	parts := strings.Split(tok, ".")
 	if len(parts) != 3 {
 		t.Fatalf("malformed token: %s", tok)
 	}
-	last := parts[2]
-	tampered := tok[:len(tok)-1]
-	if last[len(last)-1] == 'A' {
-		tampered += "B"
-	} else {
-		tampered += "A"
+	// Tamper the *first* signature byte — base64-url's last char often
+	// only encodes padding bits, so flipping it can decode to the same
+	// signature (test was flaky). The first char always carries real
+	// bits.
+	sig := parts[2]
+	first := sig[0]
+	swap := byte('A')
+	if first == 'A' {
+		swap = 'B'
 	}
+	tampered := parts[0] + "." + parts[1] + "." + string(swap) + sig[1:]
 	if _, err := s.Parse(tampered); err == nil {
 		t.Error("expected error on tampered signature")
 	}


### PR DESCRIPTION
## Summary

Second of three SEC-002 phases. Adds two Prometheus counters that
move **only** on successful authentication — `auth_basic_requests_total`
for Basic Auth and `auth_jwt_requests_total` for Bearer JWT. SEC-002c
will read the Basic counter to decide when it is safe to remove the
Basic Auth path.

Ticket: [plan/SEC-002b-basic-auth-metric.md](../tree/SEC-002b-basic-auth-metric/plan/SEC-002b-basic-auth-metric.md) (gitignored locally).

## What changed

- **`api/middleware.go`**: registers `auth_basic_requests_total` and
  `auth_jwt_requests_total` in the existing `initMetrics` `sync.Once`.
  `Authenticate` now increments the right counter on each success
  exit, and itself calls `metricsOnce.Do` defensively so the counters
  exist even when a test mounts the middleware without the `Metrics()`
  step.
- **`api/auth_metrics_test.go`** (new): scrapes `/metrics` and asserts
  counter deltas across the four-cell matrix:
  basic-success → basic moves, jwt-fail → no movement,
  jwt-success → jwt moves, basic-fail → no movement.
- **`README.md`**: documents the two metrics under Metrics, including
  the `rate(auth_basic_requests_total[1d])` expression SEC-002c will
  gate removal on.
- **`plan/SEC-002c-deprecate-basic-auth.md`**: tightened the
  threshold from prose to a concrete Prom expression.

## Hitchhiking flake fix

While verifying this branch, the SEC-002a `TestParseRejectsTampered`
and `TestProtectedRouteRejectsTamperedBearer` tests failed
intermittently (one in ~20 runs).

The tests flipped the **last** char of the JWT signature segment,
which is on a base64-url padding boundary. With HS256 producing a
32-byte signature, the last char encodes only 2 actual bits + 4
padding bits — so e.g. `A` (0b000000) and `B` (0b000001) decode to
the same final signature byte. When the original ended in `A` and
the test replaced it with `B`, the "tampered" token validated
successfully.

Fixed by flipping the **first** char of the signature segment, which
always carries real bits. Stress-tested at `-count=20 -race`.

## Acceptance criteria

- [x] `auth_basic_requests_total` increments on every successful
      Basic Auth request, never on 401.
- [x] `auth_jwt_requests_total` mirror counter for the JWT path.
- [x] README documents both metrics.
- [x] SEC-002c threshold is concrete (`rate(auth_basic_requests_total[1d])`
      flat at zero across a release cycle / one week, whichever is
      longer).

## Test plan

- [x] `make verify` (fmt, vet, lint, sec, test-race) green
- [x] `TestAuthCountersMoveOnSuccessOnly` covers all four matrix
      cells via real `/metrics` scraping
- [x] Flaky-tamper tests stress-checked at `-count=20 -race`
- [ ] Manual: hit `/api/v1/inventory` with Basic + JWT, confirm
      `/metrics` shows both counters advancing

🤖 Generated with [Claude Code](https://claude.com/claude-code)