### PR TITLE
DSN-006: secrets.Provider abstraction for the Vault Agent injector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ GME_JWT_SIGNING_KEY=replace-me-with-32-or-more-random-bytes
 # Optional. Default 900 (15 minutes).
 # GME_JWT_TTL_SECONDS=900
 
+# Secrets provider (DSN-006). Determines where the GME_* secret env
+# vars come from. Defaults to "env" (read from this file / the shell).
+# Set to "file" + GME_SECRETS_DIR for the Vault Agent injector pattern.
+# GME_SECRETS_PROVIDER=env
+# GME_SECRETS_DIR=/vault/secrets
+
 # docker-compose overrides. These ONLY affect how the dev stack containers
 # initialise themselves; the Go app reads the GME_* vars above.
 POSTGRES_USER=postgres

--- a/README.md
+++ b/README.md
@@ -170,8 +170,20 @@ Three convenient ways to supply these locally:
    `direnv`. See [.env.example](.env.example) for the shape.
 3. **`config.local.yml`** in the repo root (gitignored). Same schema as `config.yml`; merged on top at startup.
 
-In production, populate the env vars from your secret manager (Vault, AWS Secrets Manager, GCP Secret Manager) — see
-DSN-006 in the local plan/.
+In production, the env vars are populated by a **secrets provider** at process startup. Selection is via
+`GME_SECRETS_PROVIDER`:
+
+| `GME_SECRETS_PROVIDER` | Reads from | Use case |
+| --- | --- | --- |
+| unset / `env` | shell env, `.env` file | dev, CI, `go run` |
+| `file` | `GME_SECRETS_DIR` (default `/vault/secrets`) | Vault Agent injector in K8s |
+
+The application itself talks to no external secret store — the Vault Agent sidecar renders templates into a
+shared tmpfs and the app reads files. See [docs/adr/0001-secrets-management.md](docs/adr/0001-secrets-management.md)
+for the architectural decision and the rotation playbook.
+
+The required-secret list lives in [core/secrets/provider.go](core/secrets/provider.go) (`secrets.Required`); the
+provider's `Load` fails fast at startup if any are missing.
 
 #### Local stack credentials
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sksmith/go-micro-example/config"
 	"github.com/sksmith/go-micro-example/core/auth"
 	"github.com/sksmith/go-micro-example/core/inventory"
+	"github.com/sksmith/go-micro-example/core/secrets"
 	"github.com/sksmith/go-micro-example/core/user"
 	"github.com/sksmith/go-micro-example/db"
 	"github.com/sksmith/go-micro-example/db/invrepo"
@@ -28,6 +29,14 @@ import (
 func main() {
 	start := time.Now()
 	ctx := context.Background()
+
+	// Resolve secrets from the configured provider before viper reads
+	// the env (DSN-006). The provider populates GME_* env vars so the
+	// existing viper.BindEnv plumbing keeps working unchanged.
+	if err := secrets.LoadFromEnv(); err != nil {
+		log.Fatal().Err(err).Msg("secrets provider failed; refusing to start")
+	}
+
 	cfg := config.Load("config")
 
 	configLogging(cfg)

--- a/core/secrets/provider.go
+++ b/core/secrets/provider.go
@@ -1,0 +1,169 @@
+// Package secrets selects where credential-bearing env vars come from
+// at process startup (DSN-006). The Go process always reads secrets via
+// os.Getenv (so SEC-004's viper.BindEnv plumbing keeps working
+// unchanged); the provider's job is to populate those env vars from
+// somewhere appropriate to the runtime:
+//
+//   - In dev / CI, secrets come from the shell environment or a
+//     gitignored .env file. The EnvProvider verifies presence and
+//     does nothing else.
+//   - In Kubernetes, a Vault Agent sidecar renders secrets to a shared
+//     volume (default /vault/secrets/). The FileProvider reads each
+//     file and exports its content as the matching env var.
+//
+// See docs/adr/0001-secrets-management.md for the architectural
+// decision and the rationale for the Vault Agent injector pattern.
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvVar is the canonical env-var name a secret resolves to. Pre-fixed
+// with GME_ to match SEC-004's viper binding contract.
+type EnvVar string
+
+// These are env-var *names*, not credential values; gosec G101's
+// substring matcher fires on "PASS" without distinguishing.
+const (
+	DBUser        EnvVar = "GME_DB_USER"
+	DBPass        EnvVar = "GME_DB_PASS" // #nosec G101 -- env var name, not a credential
+	RabbitMQUser  EnvVar = "GME_RABBITMQ_USER"
+	RabbitMQPass  EnvVar = "GME_RABBITMQ_PASS" // #nosec G101 -- env var name, not a credential
+	JWTSigningKey EnvVar = "GME_JWT_SIGNING_KEY"
+)
+
+// Required is the closed set of secrets the application needs to start.
+// Listed centrally so the startup health check can fail fast if any
+// are missing — SEC-004's "Add a startup health check" criterion.
+var Required = []EnvVar{
+	DBUser,
+	DBPass,
+	RabbitMQUser,
+	RabbitMQPass,
+	// JWTSigningKey is intentionally NOT in Required: the auth.NewSigner
+	// strict flag handles its own prod-only enforcement, and non-prod
+	// profiles tolerate an ephemeral key.
+}
+
+// Provider populates the process environment with secret values so the
+// rest of the codebase keeps reading via os.Getenv. Implementations
+// must be idempotent and safe to call once at startup.
+type Provider interface {
+	// Load resolves and exports each requested secret as an env var.
+	// Returns an error containing every missing / unreadable secret;
+	// the caller should fail fast on a non-nil result.
+	Load(required []EnvVar) error
+}
+
+// LoadFromEnv selects a Provider based on the GME_SECRETS_PROVIDER env
+// var and runs Load against the project-wide Required list. This is
+// the entry point cmd/main.go should call once at startup, before
+// config.Load.
+//
+// Provider selection:
+//
+//   - "" or "env" — EnvProvider. Default for local dev.
+//   - "file"      — FileProvider rooted at GME_SECRETS_DIR (defaults
+//     to /vault/secrets). Use with the Vault Agent
+//     injector sidecar pattern.
+//
+// Anything else is an error.
+func LoadFromEnv() error {
+	provider, err := selectProvider()
+	if err != nil {
+		return err
+	}
+	return provider.Load(Required)
+}
+
+func selectProvider() (Provider, error) {
+	switch strings.ToLower(os.Getenv("GME_SECRETS_PROVIDER")) {
+	case "", "env":
+		return EnvProvider{}, nil
+	case "file":
+		dir := os.Getenv("GME_SECRETS_DIR")
+		if dir == "" {
+			dir = "/vault/secrets"
+		}
+		return FileProvider{Dir: dir}, nil
+	default:
+		return nil, fmt.Errorf("unknown GME_SECRETS_PROVIDER %q (want \"env\" or \"file\")", os.Getenv("GME_SECRETS_PROVIDER"))
+	}
+}
+
+// EnvProvider verifies that each required secret is already in the
+// process environment. It does not write to the environment because it
+// has nothing new to write — secrets came from the shell or a .env
+// file before the process started.
+type EnvProvider struct{}
+
+func (EnvProvider) Load(required []EnvVar) error {
+	var missing []string
+	for _, v := range required {
+		if os.Getenv(string(v)) == "" {
+			missing = append(missing, string(v))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("env-provider: missing required secrets: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// FileProvider reads secrets from files in a directory and exports each
+// as the matching env var. It is the right pairing for Vault Agent
+// injector, which renders templates into a tmpfs volume. Filenames
+// match the env-var name lowercased with leading underscores trimmed —
+// e.g. GME_DB_PASS resolves to <Dir>/gme_db_pass.
+type FileProvider struct {
+	Dir string
+}
+
+func (f FileProvider) Load(required []EnvVar) error {
+	var missing []string
+	var unreadable []string
+	for _, v := range required {
+		path := filepath.Join(f.Dir, fileNameFor(v))
+		// #nosec G304 -- path is f.Dir (operator-controlled, not user
+		// input) joined with a hard-coded env-var name from the
+		// closed Required set. There is no caller-controlled path
+		// component.
+		data, err := os.ReadFile(path)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			missing = append(missing, path)
+			continue
+		case err != nil:
+			unreadable = append(unreadable, fmt.Sprintf("%s: %v", path, err))
+			continue
+		}
+		// Trim a single trailing newline — Vault templates routinely
+		// end with one — but preserve any deliberate whitespace inside
+		// the secret.
+		value := strings.TrimRight(string(data), "\n")
+		if err := os.Setenv(string(v), value); err != nil {
+			return fmt.Errorf("file-provider: setenv %s: %w", v, err)
+		}
+	}
+	if len(missing) > 0 || len(unreadable) > 0 {
+		var msg strings.Builder
+		msg.WriteString("file-provider:")
+		if len(missing) > 0 {
+			fmt.Fprintf(&msg, " missing files: %s;", strings.Join(missing, ", "))
+		}
+		if len(unreadable) > 0 {
+			fmt.Fprintf(&msg, " unreadable files: %s;", strings.Join(unreadable, "; "))
+		}
+		return errors.New(strings.TrimRight(msg.String(), ";"))
+	}
+	return nil
+}
+
+func fileNameFor(v EnvVar) string {
+	return strings.ToLower(string(v))
+}

--- a/core/secrets/provider_test.go
+++ b/core/secrets/provider_test.go
@@ -1,0 +1,152 @@
+package secrets_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/core/secrets"
+)
+
+func TestEnvProviderPasses(t *testing.T) {
+	t.Setenv("GME_TEST_PRESENT", "value")
+	if err := (secrets.EnvProvider{}).Load([]secrets.EnvVar{"GME_TEST_PRESENT"}); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestEnvProviderReportsMissing(t *testing.T) {
+	// Prefix unlikely to exist in CI
+	const v = "GME_TEST_DOES_NOT_EXIST"
+	os.Unsetenv(v)
+	err := (secrets.EnvProvider{}).Load([]secrets.EnvVar{secrets.EnvVar(v)})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), v) {
+		t.Errorf("error %q does not name the missing var", err)
+	}
+}
+
+func TestFileProviderReadsAndExports(t *testing.T) {
+	dir := t.TempDir()
+	const v = "GME_TEST_FROM_FILE"
+	if err := os.WriteFile(filepath.Join(dir, "gme_test_from_file"), []byte("rendered-value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(v, "") // ensure unset before
+	os.Unsetenv(v)
+	t.Cleanup(func() { os.Unsetenv(v) })
+
+	if err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{secrets.EnvVar(v)}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv(v); got != "rendered-value" {
+		t.Errorf("env got=%q want=%q (trailing newline should be stripped)", got, "rendered-value")
+	}
+}
+
+func TestFileProviderPreservesInternalWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	const v = "GME_TEST_INTERNAL_WS"
+	// Inner whitespace and a trailing newline; only the trailing
+	// newline should be stripped.
+	if err := os.WriteFile(filepath.Join(dir, "gme_test_internal_ws"), []byte("a b\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Unsetenv(v) })
+	if err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{secrets.EnvVar(v)}); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(v); got != "a b\nc" {
+		t.Errorf("env got=%q want=%q", got, "a b\nc")
+	}
+}
+
+func TestFileProviderReportsMissing(t *testing.T) {
+	dir := t.TempDir()
+	err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{"GME_DB_PASS", "GME_DB_USER"})
+	if err == nil {
+		t.Fatal("expected error for missing files")
+	}
+	for _, want := range []string{"gme_db_pass", "gme_db_user"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention missing file %q", err, want)
+		}
+	}
+}
+
+func TestFileProviderReportsUnreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; permission errors don't apply")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "gme_db_pass")
+	if err := os.WriteFile(target, []byte("v"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(target, 0o600) }) // let TempDir clean up
+	err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{"GME_DB_PASS"})
+	if err == nil {
+		t.Fatal("expected error reading 0000-perm file")
+	}
+	if !strings.Contains(err.Error(), "unreadable") {
+		t.Errorf("error %q does not classify as unreadable", err)
+	}
+}
+
+func TestLoadFromEnvSelectsByEnvVar(t *testing.T) {
+	t.Run("default is env-provider", func(t *testing.T) {
+		t.Setenv("GME_SECRETS_PROVIDER", "")
+		for _, v := range secrets.Required {
+			t.Setenv(string(v), "x")
+		}
+		if err := secrets.LoadFromEnv(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("file mode requires the directory's contents", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("GME_SECRETS_PROVIDER", "file")
+		t.Setenv("GME_SECRETS_DIR", dir)
+		err := secrets.LoadFromEnv()
+		if err == nil {
+			t.Fatal("expected error from empty dir")
+		}
+		if !strings.Contains(err.Error(), "file-provider") {
+			t.Errorf("error %q does not identify the failing provider", err)
+		}
+	})
+
+	t.Run("unknown provider is rejected", func(t *testing.T) {
+		t.Setenv("GME_SECRETS_PROVIDER", "kerblam")
+		err := secrets.LoadFromEnv()
+		if err == nil || !strings.Contains(err.Error(), "unknown") {
+			t.Errorf("expected unknown-provider error, got %v", err)
+		}
+	})
+}
+
+func TestLoadFromEnvIsErrorTyped(t *testing.T) {
+	// Sanity check that callers can wrap and inspect.
+	t.Setenv("GME_SECRETS_PROVIDER", "kerblam")
+	err := secrets.LoadFromEnv()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	wrapped := wrap(err)
+	if !errors.Is(wrapped, err) {
+		t.Errorf("errors.Is failed across one level of wrapping")
+	}
+}
+
+type wrapper struct{ inner error }
+
+func (w wrapper) Error() string { return "wrapped: " + w.inner.Error() }
+func (w wrapper) Unwrap() error { return w.inner }
+
+func wrap(err error) error { return wrapper{inner: err} }

--- a/docs/adr/0001-secrets-management.md
+++ b/docs/adr/0001-secrets-management.md
@@ -1,0 +1,140 @@
+# ADR 0001 — Secrets management via Vault Agent injector
+
+- **Status:** Accepted (DSN-006).
+- **Date:** 2026-05-08.
+- **Related:** SEC-004 (env-var sourcing), DSN-006 (this decision).
+
+## Context
+
+After SEC-004, the four credential-bearing config keys (`db.user`,
+`db.pass`, `rabbitmq.user`, `rabbitmq.pass`) plus `GME_JWT_SIGNING_KEY`
+are populated from the process environment. SEC-004 satisfied "no
+secrets in tracked files" but punted on the upstream question — where
+do those env vars actually come from in production? DSN-006 picks one
+answer and bakes it into the runtime so operators are not left to
+improvise.
+
+The four candidates we considered:
+
+1. **Vault Agent injector (sidecar in Kubernetes).** Vault Agent runs
+   as a sidecar in the pod, authenticates via the Kubernetes service
+   account (Vault `auth/kubernetes` method), renders Vault templates
+   into a tmpfs volume shared with the app container, and (optionally)
+   keeps the rendered files fresh as Vault leases rotate.
+2. **Direct Vault SDK calls from the app.** Embed the
+   `hashicorp/vault/api` client, authenticate from the app, fetch
+   secrets at startup (and re-fetch periodically).
+3. **AWS Secrets Manager + AWS SDK.** Resolve secrets via the AWS
+   SDK at startup, using IRSA / instance profile auth.
+4. **Kubernetes Secrets sourced from External Secrets Operator (ESO).**
+   ESO syncs from Vault / AWS / GCP into a `Secret` resource; the pod
+   mounts it as env vars or files.
+
+## Decision
+
+We adopt **option 1 — Vault Agent injector**. The Go binary itself
+knows nothing about Vault. Authentication, leasing, retry, template
+rendering, and secret rotation all live in the sidecar.
+
+The application reads secrets from files in a directory whose path is
+configurable via `GME_SECRETS_DIR` (defaulting to `/vault/secrets`,
+the Agent injector's standard mount point). A
+`secrets.FileProvider` implementation in `core/secrets/` reads each
+file, trims a single trailing newline (which Vault templates produce
+by default), and exports the value as the matching `GME_*` env var
+**before** viper resolves config — so the existing SEC-004 plumbing
+keeps working unchanged.
+
+For dev / CI / `go run`, the same package ships a
+`secrets.EnvProvider` that does nothing but verify required variables
+are already in the environment, matching the SEC-004 contract. The
+provider is selected at startup via `GME_SECRETS_PROVIDER`:
+
+| `GME_SECRETS_PROVIDER` | Reads from | Use case |
+| --- | --- | --- |
+| unset / `env` | shell env, `.env` file | dev, CI, `go run` |
+| `file` | `GME_SECRETS_DIR` (default `/vault/secrets`) | Vault Agent injector in K8s |
+
+## Why Vault Agent injector and not the alternatives
+
+- **vs. direct Vault SDK calls.** The app would need Vault auth
+  config, retry, lease renewal, and rotation logic baked into Go
+  code. That is exactly the work the Agent already does, in a
+  CNCF-blessed sidecar. Keeping it out of the binary keeps the binary
+  simpler and lets us replace Vault later without touching the app.
+- **vs. AWS Secrets Manager.** Cloud-coupling without a clear win.
+  The team has Vault running for other services and Vault is portable
+  across clouds; AWS SM would lock us in. If we move off Vault later,
+  swapping the sidecar (e.g. for ESO) is a deploy-time change, not a
+  code change.
+- **vs. External Secrets Operator.** ESO ends up writing to
+  Kubernetes `Secret` resources, which sit at rest in etcd (encrypted
+  if so configured, but still). The Agent injector renders into
+  in-memory tmpfs — never persisted. Lower blast radius if a node is
+  compromised.
+
+## Consequences
+
+- **For the runtime.** The Go process gains exactly one new
+  dependency: the `secrets.Provider` interface plus two
+  implementations. No Vault client code; no retry; no rotation
+  logic. About 130 lines of Go, fully unit-tested.
+- **For deployment.** The K8s manifest gains the standard Vault
+  Agent injector annotations on the pod spec, and a Vault role +
+  policy + Kubernetes auth binding granted to the service account.
+  Concrete YAML belongs to OPS-004 (K8s manifests) and is **not** in
+  scope of this ADR or DSN-006 — DSN-006 just makes the app
+  injector-compatible.
+- **For rotation.** Vault Agent re-renders the template files when a
+  lease ticks. Two postures are possible:
+    1. **Restart-on-rotate.** The current minimal posture. App reads
+       env vars once at startup; a rotation requires a pod restart,
+       which is cheap on K8s and matches the project's no-graceful-
+       shutdown limitation tracked in DSN-001. Document this in the
+       rotation playbook (next section).
+    2. **Reload-without-restart.** Watch the rendered files and
+       re-resolve. Out of scope for DSN-006; revisit if rotation
+       cadence becomes painful.
+  We pick (1) on purpose: it keeps DSN-006 a single-PR change. The
+  rotation playbook below tells operators what to do.
+- **For dev workflow.** Unchanged. Devs continue to set `GME_*` env
+  vars from a `.env` file or shell. `GME_SECRETS_PROVIDER` is unset
+  by default and selects EnvProvider, which only verifies presence.
+- **For tests.** A test can either set env vars directly (the EnvProvider
+  path) or write files to a temp dir and point a `FileProvider` at it.
+  No Vault test fixture is required.
+
+## Rotation playbook (restart-on-rotate)
+
+1. Operator updates the secret in Vault (`vault kv put kv/<path>
+   db_pass=<new>`).
+2. Vault Agent re-renders the template within its lease window
+   (default ≤ 1 minute).
+3. Operator triggers a rolling restart of the deployment:
+   ```sh
+   kubectl rollout restart deploy/go-micro-example
+   ```
+4. The new pods read the freshly rendered files at startup. Old
+   pods finish in-flight requests and terminate. Zero-downtime
+   provided the deployment has more than one replica and a
+   `maxUnavailable` < replicas.
+5. The startup health check (built into `secrets.LoadFromEnv` →
+   `EnvProvider.Load` / `FileProvider.Load`) refuses to start any
+   pod that cannot resolve every required secret.
+
+## Out of scope (filed elsewhere)
+
+- **Concrete K8s manifests** with Vault Agent annotations →
+  **OPS-004**.
+- **Reload-without-restart** for rotation → potential follow-up if
+  cadence demands it; not filed today.
+- **Bootstrap admin password** (`BOOTSTRAP_ADMIN_PASSWORD`) is
+  intentionally not part of `secrets.Required`. It is a one-shot,
+  optional input read directly via `os.Getenv` in `cmd/main.go`. If
+  we later want it in Vault too, dropping it into `secrets.Required`
+  is one line.
+- **JWT signing key** (`GME_JWT_SIGNING_KEY`) is *also* deliberately
+  not in `secrets.Required`. The `auth.NewSigner` strict flag
+  enforces presence in `prod` profile and tolerates an ephemeral key
+  elsewhere. Adding it to `Required` would force prod-style
+  enforcement onto every profile.


### PR DESCRIPTION
## Summary

Closes the design partner of SEC-004. After SEC-004 moved credentials
out of tracked files into env vars, this PR picks the production
backend (**Vault Agent injector**) and makes the runtime compatible
with it. The Go binary itself talks to no external secret store —
the Agent sidecar renders secrets to a tmpfs volume, the app reads
files and exports env vars at startup, and the existing SEC-004
viper bindings keep working unchanged.

The architectural decision and the alternatives considered are
recorded in [docs/adr/0001-secrets-management.md](../tree/DSN-006-config-secrets-vault/docs/adr/0001-secrets-management.md).
That file is the substance of this PR; the code is small.

Ticket: [plan/DSN-006-config-secrets-vault.md](../tree/DSN-006-config-secrets-vault/plan/DSN-006-config-secrets-vault.md) (gitignored locally).

## What changed

- **`core/secrets/provider.go`** (new package, ~130 lines):
  `Provider` interface + `EnvProvider` (verify required env vars are
  present; no I/O) + `FileProvider` (read files from a directory,
  trim a single trailing newline, `os.Setenv` each value). The
  `LoadFromEnv()` factory selects via `GME_SECRETS_PROVIDER`
  (`""` / `"env"` / `"file"`); `FileProvider.Dir` defaults to
  `/vault/secrets`, the Agent injector mount point.
- **`core/secrets/provider_test.go`** (~150 lines): env present +
  missing, file read-and-export, internal-whitespace preservation,
  missing files, unreadable files (skipped as root), provider
  selection happy path, unknown provider rejected.
- **`cmd/main.go`**: calls `secrets.LoadFromEnv()` **before**
  `config.Load`, so the provider populates env vars before viper
  reads them. Fail-fast on any error.
- **`docs/adr/0001-secrets-management.md`** (new): the decision,
  the four alternatives, why Vault Agent injector won, the
  restart-on-rotate playbook, what is intentionally out of scope.
- **README + .env.example**: document the new env vars and link
  to the ADR.

## Acceptance criteria

- [x] **Documented decision (ADR)** selecting one secret backend —
      ADR 0001 picks Vault Agent injector with rationale.
- [x] **Code reads secrets via a small `secrets.Provider`
      abstraction** with a local-file (Vault Agent compatible)
      implementation for prod and an env-only implementation for
      dev / CI.
- [x] **Secret rotation playbook documented** — restart-on-rotate
      under "Rotation playbook" in the ADR.
- [x] **Startup health check** — `Provider.Load` fails fast if any
      required secret is missing; `cmd/main.go` calls it before
      anything else and `log.Fatal`s on error.

## Notes / scope decisions

- **Vault Agent injector vs. direct Vault SDK calls.** Picking the
  sidecar means the Go binary stays simpler — no Vault auth, no
  retry, no lease renewal, no rotation logic in code. Replacing
  Vault later (e.g. for External Secrets Operator) becomes a
  deploy-time change rather than a code change.
- **`BOOTSTRAP_ADMIN_PASSWORD` (SEC-003) deliberately not in
  `secrets.Required`.** It's a one-shot, optional input handled by
  `user.Bootstrap`; adding it would force prod-style enforcement on
  every profile.
- **`GME_JWT_SIGNING_KEY` (SEC-002a) also not in `Required`.**
  `auth.NewSigner` strict flag enforces presence in `prod` and
  tolerates ephemeral keys elsewhere; same reasoning.
- **Concrete K8s manifests with Vault Agent annotations** belong to
  **OPS-004**. DSN-006 only makes the app injector-compatible.
- **Two `#nosec` comments** in [core/secrets/provider.go](core/secrets/provider.go):
  G304 (file inclusion via variable) on the `os.ReadFile(path)`
  call, and G101 (hardcoded credentials substring match on "PASS")
  on the `DBPass` / `RabbitMQPass` env-var-name constants. Both
  are false positives — paths are operator-supplied `Dir` + closed-
  set env-var name, and the matched constants are env-var *names*,
  not credential values. Justifications are inline.

## Test plan

- [x] `make verify` (fmt, vet, lint, sec, test-race) green
- [x] Unit: env-provider passes when present, fails with the
      missing names listed
- [x] Unit: file-provider reads, exports, trims trailing newline,
      preserves internal whitespace
- [x] Unit: file-provider lists every missing path and every
      unreadable path in one error
- [x] Unit: provider selection — default, file mode, unknown
      rejected
- [ ] Manual: `GME_SECRETS_PROVIDER=file GME_SECRETS_DIR=/tmp/x
      go run ./cmd` against a populated `/tmp/x` → app starts
- [ ] Manual: same but with `/tmp/x` empty → app fails fast with
      `file-provider: missing files: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)