### PR TITLE
DEP-005: replace pkg/errors with stdlib errors + %w

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/rs/zerolog/pkgerrors"
 	"github.com/sksmith/go-micro-example/api"
 	"github.com/sksmith/go-micro-example/config"
 	"github.com/sksmith/go-micro-example/core/inventory"
@@ -40,7 +39,6 @@ func TestMain(m *testing.M) {
 		log.Fatal().Err(err)
 	}
 	zerolog.SetGlobalLevel(level)
-	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
 	cfg.Print()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/rs/zerolog/pkgerrors"
 	"github.com/sksmith/go-micro-example/api"
 	"github.com/sksmith/go-micro-example/config"
 	"github.com/sksmith/go-micro-example/core/auth"
@@ -152,5 +151,4 @@ func configLogging(cfg *config.Config) {
 	}
 	log.Info().Str("loglevel", level.String()).Msg("setting log level")
 	zerolog.SetGlobalLevel(level)
-	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 }

--- a/core/inventory/model.go
+++ b/core/inventory/model.go
@@ -5,7 +5,7 @@ package inventory
 import (
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // ProductionRequest is a value object. A request to produce inventory.

--- a/core/inventory/service.go
+++ b/core/inventory/service.go
@@ -2,12 +2,13 @@ package inventory
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core"
 )
@@ -43,7 +44,7 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 
 	dbProduct, err := s.repo.GetProduct(ctx, product.Sku)
 	if err != nil != errors.Is(err, core.ErrNotFound) {
-		return errors.WithStack(err)
+		return err
 	}
 	if err == nil {
 		log.Debug().Str("func", funcName).Str("sku", dbProduct.Sku).Msg("product already exists")
@@ -52,7 +53,7 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 
 	tx, err := s.repo.BeginTransaction(ctx)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer func() {
 		if err != nil {
@@ -62,18 +63,18 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 
 	log.Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product")
 	if err = s.repo.SaveProduct(ctx, product, core.UpdateOptions{Tx: tx}); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	log.Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product inventory")
 	pi := ProductInventory{Product: product}
 
 	if err = s.repo.SaveProductInventory(ctx, pi, core.UpdateOptions{Tx: tx}); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -98,7 +99,7 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 
 	event, err := s.repo.GetProductionEventByRequestID(ctx, pr.RequestID)
 	if err != nil && !errors.Is(err, core.ErrNotFound) {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if event.RequestID != "" {
@@ -115,7 +116,7 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 
 	tx, err := s.repo.BeginTransaction(ctx)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer func() {
 		if err != nil {
@@ -124,30 +125,30 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 	}()
 
 	if err = s.repo.SaveProductionEvent(ctx, &event, core.UpdateOptions{Tx: tx}); err != nil {
-		return errors.WithMessage(err, "failed to save production event")
+		return fmt.Errorf("failed to save production event: %w", err)
 	}
 
 	productInventory, err := s.repo.GetProductInventory(ctx, product.Sku, core.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil {
-		return errors.WithMessage(err, "failed to get product inventory")
+		return fmt.Errorf("failed to get product inventory: %w", err)
 	}
 
 	productInventory.Available += event.Quantity
 	if err = s.repo.SaveProductInventory(ctx, productInventory, core.UpdateOptions{Tx: tx}); err != nil {
-		return errors.WithMessage(err, "failed to add production to product")
+		return fmt.Errorf("failed to add production to product: %w", err)
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return errors.WithMessage(err, "failed to commit production transaction")
+		return fmt.Errorf("failed to commit production transaction: %w", err)
 	}
 
 	err = s.publishInventory(ctx, productInventory)
 	if err != nil {
-		return errors.WithMessage(err, "failed to publish inventory")
+		return fmt.Errorf("failed to publish inventory: %w", err)
 	}
 
 	if err = s.FillReserves(ctx, product); err != nil {
-		return errors.WithMessage(err, "failed to fill reserves after production")
+		return fmt.Errorf("failed to fill reserves after production: %w", err)
 	}
 
 	return nil
@@ -181,13 +182,13 @@ func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservati
 	pr, err := s.repo.GetProduct(ctx, rr.Sku, core.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil {
 		log.Error().Err(err).Str("requestId", rr.RequestID).Msg("failed to get product")
-		return Reservation{}, errors.WithStack(err)
+		return Reservation{}, err
 	}
 
 	res, err := s.repo.GetReservationByRequestID(ctx, rr.RequestID, core.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil && !errors.Is(err, core.ErrNotFound) {
 		log.Error().Err(err).Str("requestId", rr.RequestID).Msg("failed to get reservation request")
-		return Reservation{}, errors.WithStack(err)
+		return Reservation{}, err
 	}
 	if res.RequestID != "" {
 		log.Debug().Str("func", funcName).Str("requestId", rr.RequestID).Msg("reservation already exists, returning it")
@@ -205,15 +206,15 @@ func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservati
 	}
 
 	if err = s.repo.SaveReservation(ctx, &res, core.UpdateOptions{Tx: tx}); err != nil {
-		return Reservation{}, errors.WithStack(err)
+		return Reservation{}, err
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return Reservation{}, errors.WithStack(err)
+		return Reservation{}, err
 	}
 
 	if err = s.FillReserves(ctx, pr); err != nil {
-		return Reservation{}, errors.WithStack(err)
+		return Reservation{}, err
 	}
 
 	return res, nil
@@ -246,7 +247,7 @@ func (s *service) GetProduct(ctx context.Context, sku string) (Product, error) {
 
 	product, err := s.repo.GetProduct(ctx, sku)
 	if err != nil {
-		return product, errors.WithStack(err)
+		return product, err
 	}
 	return product, nil
 }
@@ -258,7 +259,7 @@ func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductI
 
 	product, err := s.repo.GetProductInventory(ctx, sku)
 	if err != nil {
-		return product, errors.WithStack(err)
+		return product, err
 	}
 	return product, nil
 }
@@ -270,7 +271,7 @@ func (s *service) GetReservation(ctx context.Context, ID uint64) (Reservation, e
 
 	rsv, err := s.repo.GetReservation(ctx, ID)
 	if err != nil {
-		return rsv, errors.WithStack(err)
+		return rsv, err
 	}
 	return rsv, nil
 }
@@ -286,7 +287,7 @@ func (s *service) GetReservations(ctx context.Context, options GetReservationsOp
 
 	rsv, err := s.repo.GetReservations(ctx, options, limit, offset)
 	if err != nil {
-		return rsv, errors.WithStack(err)
+		return rsv, err
 	}
 	return rsv, nil
 }
@@ -339,17 +340,17 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 		}
 	}()
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	openReservations, err := s.repo.GetReservations(ctx, GetReservationsOptions{Sku: product.Sku, State: Open}, 100, 0, core.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	productInventory, err := s.repo.GetProductInventory(ctx, product.Sku, core.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	for _, reservation := range openReservations {
@@ -395,7 +396,7 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 
 		err = s.repo.SaveProductInventory(ctx, productInventory, core.UpdateOptions{Tx: tx})
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		log.Debug().
@@ -407,26 +408,26 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 
 		err = s.repo.UpdateReservation(ctx, reservation.ID, reservation.State, reservation.ReservedQuantity, core.UpdateOptions{Tx: tx})
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		if err = subtx.Commit(ctx); err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		err = s.publishInventory(ctx, productInventory)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		err = s.publishReservation(ctx, reservation)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil
@@ -435,7 +436,7 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 func (s *service) publishInventory(ctx context.Context, pi ProductInventory) error {
 	err := s.queue.PublishInventory(ctx, pi)
 	if err != nil {
-		return errors.WithMessage(err, "failed to publish inventory to queue")
+		return fmt.Errorf("failed to publish inventory to queue: %w", err)
 	}
 	go s.notifyInventorySubscribers(pi)
 	return nil
@@ -444,7 +445,7 @@ func (s *service) publishInventory(ctx context.Context, pi ProductInventory) err
 func (s *service) publishReservation(ctx context.Context, r Reservation) error {
 	err := s.queue.PublishReservation(ctx, r)
 	if err != nil {
-		return errors.WithMessage(err, "failed to publish reservation to queue")
+		return fmt.Errorf("failed to publish reservation to queue: %w", err)
 	}
 	go s.notifyReservationSubscribers(r)
 	return nil

--- a/core/inventory/service_test.go
+++ b/core/inventory/service_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"errors"
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/sksmith/go-micro-example/core"
 	"github.com/sksmith/go-micro-example/core/inventory"
 	"github.com/sksmith/go-micro-example/db"

--- a/core/user/bootstrap.go
+++ b/core/user/bootstrap.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core"
 	"golang.org/x/crypto/bcrypt"
@@ -49,7 +49,7 @@ func Bootstrap(ctx context.Context, repo Repository, profile, bootstrapPassword 
 	case errors.Is(getErr, core.ErrNotFound):
 		// fall through; create below
 	case getErr != nil:
-		return errors.WithStack(getErr)
+		return getErr
 	case hasSeedAdmin:
 		log.Warn().Str("username", AdminUsername).Msg("seed admin password detected; replacing")
 	default:
@@ -64,12 +64,12 @@ func Bootstrap(ctx context.Context, repo Repository, profile, bootstrapPassword 
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if hasSeedAdmin {
 		if err := repo.Delete(ctx, AdminUsername); err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 	}
 
@@ -79,7 +79,7 @@ func Bootstrap(ctx context.Context, repo Repository, profile, bootstrapPassword 
 		IsAdmin:        true,
 	}
 	if err := repo.Create(ctx, u); err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if generated {
@@ -102,7 +102,7 @@ func resolveBootstrapPassword(profile, supplied string) (password string, genera
 	}
 	gen, err := generatePassword()
 	if err != nil {
-		return "", false, errors.WithStack(err)
+		return "", false, err
 	}
 	return gen, true, nil
 }

--- a/core/user/service.go
+++ b/core/user/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core"
 	"golang.org/x/crypto/bcrypt"

--- a/db/db.go
+++ b/db/db.go
@@ -11,7 +11,6 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/tracelog"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/config"
@@ -56,7 +55,7 @@ func newDbConfig() dbconfig {
 
 func poolSizeToInt32(v int64, name string) (int32, error) {
 	if v < 0 || v > math.MaxInt32 {
-		return 0, errors.Errorf("%s out of range for int32: %d", name, v)
+		return 0, fmt.Errorf("%s out of range for int32: %d", name, v)
 	}
 	return int32(v), nil
 }

--- a/db/invrepo/repo.go
+++ b/db/invrepo/repo.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core"
 	"github.com/sksmith/go-micro-example/core/inventory"
@@ -34,7 +33,7 @@ func (d *dbRepo) SaveProduct(ctx context.Context, product inventory.Product, opt
 		product.Sku, product.Upc, product.Name)
 	if err != nil {
 		m.Complete(nil)
-		return errors.WithStack(err)
+		return err
 	}
 	if ct.RowsAffected() == 0 {
 		_, err := tx.Exec(ctx, `
@@ -61,7 +60,7 @@ func (d *dbRepo) SaveProductInventory(ctx context.Context, productInventory inve
 		productInventory.Sku, productInventory.Available)
 	if err != nil {
 		m.Complete(nil)
-		return errors.WithStack(err)
+		return err
 	}
 	if ct.RowsAffected() == 0 {
 		insert := `INSERT INTO product_inventory (sku, available)
@@ -87,9 +86,9 @@ func (d *dbRepo) GetProduct(ctx context.Context, sku string, options ...core.Que
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return product, errors.WithStack(core.ErrNotFound)
+			return product, core.ErrNotFound
 		}
-		return product, errors.WithStack(err)
+		return product, err
 	}
 
 	m.Complete(nil)
@@ -107,9 +106,9 @@ func (d *dbRepo) GetProductInventory(ctx context.Context, sku string, options ..
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return productInventory, errors.WithStack(core.ErrNotFound)
+			return productInventory, core.ErrNotFound
 		}
-		return productInventory, errors.WithStack(err)
+		return productInventory, err
 	}
 
 	m.Complete(nil)
@@ -127,9 +126,9 @@ func (d *dbRepo) GetAllProductInventory(ctx context.Context, limit int, offset i
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return products, errors.WithStack(core.ErrNotFound)
+			return products, core.ErrNotFound
 		}
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -139,9 +138,9 @@ func (d *dbRepo) GetAllProductInventory(ctx context.Context, limit int, offset i
 		if err != nil {
 			m.Complete(err)
 			if err == pgx.ErrNoRows {
-				return nil, errors.WithStack(core.ErrNotFound)
+				return nil, core.ErrNotFound
 			}
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		products = append(products, product)
 	}
@@ -161,9 +160,9 @@ func (d *dbRepo) GetProductionEventByRequestID(ctx context.Context, requestID st
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return pe, errors.WithStack(core.ErrNotFound)
+			return pe, core.ErrNotFound
 		}
-		return pe, errors.WithStack(err)
+		return pe, err
 	}
 
 	m.Complete(nil)
@@ -181,9 +180,9 @@ func (d *dbRepo) SaveProductionEvent(ctx context.Context, event *inventory.Produ
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return errors.WithStack(core.ErrNotFound)
+			return core.ErrNotFound
 		}
-		return errors.WithStack(err)
+		return err
 	}
 	m.Complete(nil)
 	return nil
@@ -199,9 +198,9 @@ func (d *dbRepo) SaveReservation(ctx context.Context, r *inventory.Reservation, 
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return errors.WithStack(core.ErrNotFound)
+			return core.ErrNotFound
 		}
-		return errors.WithStack(err)
+		return err
 	}
 	m.Complete(nil)
 	return nil
@@ -215,7 +214,7 @@ func (d *dbRepo) UpdateReservation(ctx context.Context, ID uint64, state invento
 	_, err := tx.Exec(ctx, update, ID, state, qty)
 	m.Complete(err)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	m.Complete(nil)
 	return nil
@@ -263,9 +262,9 @@ func (d *dbRepo) GetReservations(ctx context.Context, resOptions inventory.GetRe
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return reservations, errors.WithStack(core.ErrNotFound)
+			return reservations, core.ErrNotFound
 		}
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -294,9 +293,9 @@ func (d *dbRepo) GetReservationByRequestID(ctx context.Context, requestId string
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return r, errors.WithStack(core.ErrNotFound)
+			return r, core.ErrNotFound
 		}
-		return r, errors.WithStack(err)
+		return r, err
 	}
 
 	m.Complete(nil)
@@ -314,9 +313,9 @@ func (d *dbRepo) GetReservation(ctx context.Context, ID uint64, options ...core.
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return r, errors.WithStack(core.ErrNotFound)
+			return r, core.ErrNotFound
 		}
-		return r, errors.WithStack(err)
+		return r, err
 	}
 
 	m.Complete(nil)

--- a/db/usrrepo/repo.go
+++ b/db/usrrepo/repo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core"
 	"github.com/sksmith/go-micro-example/core/user"
@@ -66,9 +65,9 @@ func (r *dbRepo) Get(ctx context.Context, username string, txs ...core.QueryOpti
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return user.User{}, errors.WithStack(core.ErrNotFound)
+			return user.User{}, core.ErrNotFound
 		}
-		return user.User{}, errors.WithStack(err)
+		return user.User{}, err
 	}
 
 	r.cache(u)
@@ -85,9 +84,9 @@ func (r *dbRepo) Delete(ctx context.Context, username string, txs ...core.Update
 	if err != nil {
 		m.Complete(err)
 		if err == pgx.ErrNoRows {
-			return errors.WithStack(core.ErrNotFound)
+			return core.ErrNotFound
 		}
-		return errors.WithStack(err)
+		return err
 	}
 
 	r.uncache(username)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/pashagolub/pgxmock/v4 v4.9.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
 	github.com/rabbitmq/amqp091-go v1.11.0
 	github.com/rs/zerolog v1.20.0

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/config"
@@ -53,7 +52,7 @@ func getUrl(cfg *config.Config) string {
 func (i *InventoryQueue) PublishInventory(ctx context.Context, productInventory inventory.ProductInventory) error {
 	body, err := json.Marshal(productInventory)
 	if err != nil {
-		return errors.WithMessage(err, "failed to serialize message for queue")
+		return fmt.Errorf("failed to serialize message for queue: %w", err)
 	}
 	i.inventory <- message(body)
 	return nil
@@ -62,7 +61,7 @@ func (i *InventoryQueue) PublishInventory(ctx context.Context, productInventory 
 func (i *InventoryQueue) PublishReservation(ctx context.Context, reservation inventory.Reservation) error {
 	body, err := json.Marshal(reservation)
 	if err != nil {
-		return errors.WithMessage(err, "error marshalling reservation to send to queue")
+		return fmt.Errorf("error marshalling reservation to send to queue: %w", err)
 	}
 	i.reservation <- message(body)
 	return nil

--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -5,11 +5,9 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/rs/zerolog/pkgerrors"
 )
 
 func ConfigLogging() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
-	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 }


### PR DESCRIPTION
## Summary
\`pkg/errors\` has been in maintenance for years. Stdlib \`errors\` (with \`%w\`, \`errors.Is\`, \`errors.As\`) covers every use case here.

Mechanical substitutions:
- \`errors.WithMessage(err, \"x\")\` → \`fmt.Errorf(\"x: %w\", err)\`
- \`errors.Errorf(...)\` → \`fmt.Errorf(...)\`
- \`errors.WithStack(err)\` → \`err\`
- \`errors.New\`, \`errors.Is\`, \`errors.As\` are byte-identical between the two packages — just an import path swap.

\`pkg/errors\` is gone from \`go.mod\` entirely (was an indirect via \`zerolog/pkgerrors\`).

## Behavior change
Stack traces in zerolog logs go away. \`pkg/errors\` attached \`StackTrace()\` to wrapped errors and \`zerolog/pkgerrors\` rendered them via \`ErrorStackMarshaler\`. Stdlib \`%w\` doesn't carry stacks, so the marshaler became inert; this PR also removes the \`pkgerrors\` import + the \`ErrorStackMarshaler\` line from \`cmd/main.go\`, \`cmd/integration_test.go\`, and (leftover from TST-001) \`testutil/logging.go\`.

The \`%w\` chain is preserved, so \`errors.Is\` / \`errors.As\` still work for sentinel and typed-error checks. Anyone wanting per-frame stacks back should do it via \`slog\` / OTel, not by re-introducing \`pkg/errors\`.

## Test plan
- [x] \`make verify\` (fmt, vet, lint, sec, race tests) clean locally
- [ ] CI matrix green on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)