### PR TITLE
DEP-009: Dependabot for gomod / actions / docker + auto-merge for patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# DEP-009: Dependabot covers all three surfaces called out in the
+# ticket — Go modules, GitHub Actions, Docker base images. Weekly
+# cadence keeps PR pressure manageable; grouping rolls up the
+# families that almost always need to move together so we don't
+# get five PRs for x/sys + x/sync + x/text + x/crypto + x/text on
+# the same day.
+#
+# Patch-level updates are eligible for auto-merge once CI is
+# green; the workflow that enables that is in
+# .github/workflows/dependabot-auto-merge.yml.
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      jackc-pgx:
+        patterns:
+          - "github.com/jackc/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+      grpc-protobuf:
+        patterns:
+          - "google.golang.org/grpc"
+          - "google.golang.org/protobuf"
+          - "google.golang.org/genproto*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+# DEP-009: enable auto-merge on Dependabot PRs that pass CI when
+# the update is a patch bump. Minor and major bumps are left for
+# human review — that's where API drift hides.
+#
+# This workflow only *enables* auto-merge; it does not force it.
+# GitHub still waits for required status checks (the test /
+# lint / sec / vuln / trivy / secret matrix in main.yml) before
+# the PR actually merges. If a check goes red, the PR sits with
+# auto-merge enabled until the failure is resolved or the PR is
+# closed.
+#
+# Prerequisites in repo settings (one-time, by repo admin):
+# - Settings → General → Pull Requests → "Allow auto-merge" ON
+# - Branch protection on master requires the relevant CI checks
+#
+# Permissions: contents:write so the merge can land; pull-requests:
+# write to call gh pr merge --auto and gh pr review --approve.
+
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Closes the loop on the DEP-001..008 sweep. Without automation, the state we just established rots again.

Picked **Dependabot** over Renovate: single-service repo doesn't justify Renovate's grouping dashboard or cross-repo presets, no external GitHub App install required, native to GitHub.

### \`.github/dependabot.yml\`
Three ecosystems, weekly Monday cadence:
- **gomod** — limit 10 PRs. Groups roll up the families that always move together: \`golang.org/x/*\`, \`jackc/*\`, \`prometheus/*\`, \`go.opentelemetry.io/*\`, \`google.golang.org/{grpc,protobuf,genproto*}\`.
- **github-actions** — limit 5 PRs, all actions in one group.
- **docker** — limit 3 PRs, watches the Dockerfile base.

### \`.github/workflows/dependabot-auto-merge.yml\`
- Triggers on \`pull_request_target\` for PRs opened by \`dependabot[bot]\`.
- Reads the update type via \`dependabot/fetch-metadata@v2\`.
- For \`semver-patch\` updates, approves and enables auto-merge with squash. **Required CI checks must still pass** before the merge actually lands — auto-merge just removes the manual click.
- Minor and major bumps are left for human review.

## ⚠️ Repo-admin one-time prerequisites

Before this PR's auto-merge actually fires, you need to flip two switches in repo settings:

1. **Settings → General → Pull Requests → "Allow auto-merge"** ON
2. **Branch protection on \`master\`** requires the relevant CI checks (\`test\`, \`lint\`, \`sec\`, \`vuln\`, \`trivy\`, \`secret\`)

Both are documented in the workflow's header comment.

## Out of scope
DEP-011's "verify the bot has actually opened at least one update PR end-to-end" criterion is its own ticket. This PR sets up config; DEP-011 is the smoke test once Dependabot has had a Monday to do its thing.

## Test plan
- [x] \`make verify\` clean locally (config files only, no Go changes)
- [ ] CI matrix green on Linux/macOS/Windows
- [ ] After merge: confirm Dependabot's first scheduled run produces grouped PRs as expected (DEP-011 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)