### PR TITLE
DSN-001: graceful HTTP shutdown on SIGINT/SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Database migration is automated in the project using [migrate](https://github.co
 - [Error handling conventions](docs/errors.md) — sentinels, wrapping
   with `%w`, `errors.Is`/`errors.As`, log shape. Enforced by
   `errorlint` and `errname` in CI.
+- [Process lifecycle](docs/lifecycle.md) — startup ordering and the
+  graceful-shutdown sequence (DSN-001).
 
 ## TODO
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,9 +28,23 @@ import (
 	"github.com/common-nighthawk/go-figure"
 )
 
+// defaultShutdownTimeout caps how long we'll wait for in-flight
+// HTTP requests to drain after a SIGTERM/SIGINT. The orchestrator
+// (Kubernetes by default) sends SIGKILL after terminationGracePeriodSeconds
+// — make sure this stays below that. Override with
+// GME_SHUTDOWN_TIMEOUT_SECONDS, matching the same env-var pattern
+// used by GME_JWT_TTL_SECONDS.
+const defaultShutdownTimeout = 30 * time.Second
+
 func main() {
 	start := time.Now()
-	ctx := context.Background()
+
+	// signal.NotifyContext gives us a context that cancels on
+	// SIGINT (Ctrl-C) or SIGTERM (Kubernetes pod eviction,
+	// systemd stop). Long-lived subsystems (queue redial loops)
+	// thread this ctx so they unwind together.
+	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
 
 	// Resolve secrets from the configured provider before viper reads
 	// the env (DSN-006). The provider populates GME_* env vars so the
@@ -64,7 +81,6 @@ func main() {
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 
-	log.Info().Str("port", cfg.Port.Value).Int64("startTimeMs", time.Since(start).Milliseconds()).Msg("listening")
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port.Value,
 		Handler:           r,
@@ -73,7 +89,83 @@ func main() {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	log.Fatal().Err(srv.ListenAndServe())
+
+	// Run ListenAndServe in a goroutine so main can wait on
+	// the signal context without blocking the listener.
+	serveErr := make(chan error, 1)
+	go func() {
+		log.Info().Str("port", cfg.Port.Value).Int64("startTimeMs", time.Since(start).Milliseconds()).Msg("listening")
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+		}
+		close(serveErr)
+	}()
+
+	select {
+	case err := <-serveErr:
+		// ListenAndServe returned a non-graceful error before any
+		// signal arrived (e.g. port in use). Log and exit.
+		log.Fatal().Err(err).Msg("HTTP server failed")
+	case <-ctx.Done():
+		log.Info().Str("signal", "received").Msg("graceful shutdown beginning")
+	}
+
+	shutdown(srv, dbPool)
+}
+
+// shutdown runs the ordered teardown after a SIGTERM / SIGINT:
+//
+//  1. Stop accepting new HTTP requests; let in-flight requests
+//     drain up to the configured timeout (shutdownHTTP).
+//  2. Close the pgx pool, releasing connections back to Postgres.
+//
+// AMQP consumer drain (the queue subsystem) is deferred to
+// TST-003 — the existing redial loop in queue/queue.go cooperates
+// with ctx cancellation but doesn't expose a "finish in-flight
+// deliveries then exit" surface. The fix needs the queue to grow
+// a Close method, which sits more naturally with the test suite
+// that ticket sets up.
+func shutdown(srv *http.Server, pool *pgxpool.Pool) {
+	shutdownHTTP(srv, resolveShutdownTimeout())
+	log.Info().Msg("closing database pool")
+	pool.Close()
+	log.Info().Msg("shutdown complete")
+}
+
+// shutdownHTTP stops the server's listeners and waits for in-flight
+// requests to finish, up to the supplied timeout. On timeout (or
+// any other Shutdown error) it falls back to srv.Close, which drops
+// the remaining idle connections immediately.
+func shutdownHTTP(srv *http.Server, timeout time.Duration) {
+	log.Info().Dur("timeout", timeout).Msg("shutting down HTTP server")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Error().Err(err).Msg("HTTP server shutdown returned an error; forcing close")
+		if closeErr := srv.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+			log.Error().Err(closeErr).Msg("HTTP server force close failed")
+		}
+		return
+	}
+	log.Info().Msg("HTTP server stopped cleanly")
+}
+
+func resolveShutdownTimeout() time.Duration {
+	raw := os.Getenv("GME_SHUTDOWN_TIMEOUT_SECONDS")
+	if raw == "" {
+		return defaultShutdownTimeout
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		log.Warn().
+			Str("GME_SHUTDOWN_TIMEOUT_SECONDS", raw).
+			Dur("default", defaultShutdownTimeout).
+			Msg("invalid shutdown timeout; using default")
+		return defaultShutdownTimeout
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func printLogHeader(cfg *config.Config) {

--- a/cmd/shutdown_test.go
+++ b/cmd/shutdown_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestShutdownHTTPDrainsInFlight is the regression test for
+// DSN-001's central guarantee: a request that's already on the
+// wire when shutdown begins must finish, not get dropped. We
+// start a server with a slow handler, fire a request that sleeps
+// 200ms, kick off shutdown 50ms in, and assert the request
+// completes with 200 and shutdownHTTP returns within the deadline.
+func TestShutdownHTTPDrainsInFlight(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-r.Context().Done():
+			t.Errorf("handler context cancelled mid-request: %v", r.Context().Err())
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: time.Second}
+
+	serveDone := make(chan struct{})
+	go func() {
+		_ = srv.Serve(ln)
+		close(serveDone)
+	}()
+
+	// Fire the slow request. Use a separate client with a generous
+	// timeout so we don't false-fail on the test's own deadline.
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp := make(chan *http.Response, 1)
+	reqErr := make(chan error, 1)
+	go func() {
+		r, err := client.Get("http://" + ln.Addr().String() + "/slow")
+		if err != nil {
+			reqErr <- err
+			return
+		}
+		resp <- r
+	}()
+
+	// Wait for the handler to actually start before shutting down,
+	// otherwise the test reduces to "Shutdown rejects new conns"
+	// instead of "Shutdown drains in-flight."
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler never started")
+	}
+
+	shutdownStart := time.Now()
+	shutdownHTTP(srv, 2*time.Second)
+	shutdownDur := time.Since(shutdownStart)
+
+	select {
+	case r := <-resp:
+		defer func() { _ = r.Body.Close() }()
+		if r.StatusCode != http.StatusOK {
+			t.Errorf("got status %d, want 200", r.StatusCode)
+		}
+	case err := <-reqErr:
+		t.Fatalf("in-flight request failed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("in-flight request never completed")
+	}
+
+	if shutdownDur > 2*time.Second {
+		t.Errorf("shutdownHTTP took %s, exceeded its own 2s deadline", shutdownDur)
+	}
+
+	<-serveDone
+}
+
+// TestShutdownHTTPHonorsDeadline asserts that a request that runs
+// past the shutdown timeout doesn't keep the server alive forever.
+// shutdownHTTP must return within ~timeout, even if the handler
+// is still going.
+func TestShutdownHTTPHonorsDeadline(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	hangCtx, cancelHang := context.WithCancel(context.Background())
+	t.Cleanup(cancelHang)
+
+	mux := http.NewServeMux()
+	var once sync.Once
+	mux.HandleFunc("/hang", func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(handlerStarted) })
+		<-hangCtx.Done()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: time.Second}
+
+	go func() { _ = srv.Serve(ln) }()
+
+	go func() {
+		// Fire the hanging request and drop the response; we only
+		// care about the server's behaviour.
+		req, _ := http.NewRequestWithContext(hangCtx, http.MethodGet, "http://"+ln.Addr().String()+"/hang", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp != nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler never started")
+	}
+
+	const deadline = 100 * time.Millisecond
+	shutdownStart := time.Now()
+	shutdownHTTP(srv, deadline)
+	shutdownDur := time.Since(shutdownStart)
+
+	// Allow generous slack — CI runners are slow — but the upper
+	// bound has to be well under "forever."
+	if shutdownDur > 2*time.Second {
+		t.Errorf("shutdownHTTP took %s with a %s deadline; expected forced close", shutdownDur, deadline)
+	}
+
+	// Belt-and-braces: the listener should be closed.
+	if _, err := net.DialTimeout("tcp", ln.Addr().String(), 100*time.Millisecond); err == nil {
+		t.Error("listener still accepting connections after shutdownHTTP returned")
+	} else if !isConnRefused(err) {
+		// Either connection refused (good) or something equivalent
+		// is fine; we just don't want a successful dial.
+		t.Logf("dial after shutdown: %v (acceptable)", err)
+	}
+}
+
+func TestResolveShutdownTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "unset uses default", env: "", want: defaultShutdownTimeout},
+		{name: "valid integer is honored", env: "5", want: 5 * time.Second},
+		{name: "non-numeric falls back to default", env: "thirty", want: defaultShutdownTimeout},
+		{name: "zero is rejected (default)", env: "0", want: defaultShutdownTimeout},
+		{name: "negative is rejected (default)", env: "-1", want: defaultShutdownTimeout},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("GME_SHUTDOWN_TIMEOUT_SECONDS", test.env)
+			if got := resolveShutdownTimeout(); got != test.want {
+				t.Errorf("got=%s want=%s", got, test.want)
+			}
+		})
+	}
+}
+
+func isConnRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr *net.OpError
+	return errors.As(err, &netErr)
+}

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,75 @@
+# Process lifecycle
+
+## Startup
+[cmd/main.go](../cmd/main.go) builds dependencies in this order
+and fails fast (`log.Fatal`) on any step:
+
+1. `secrets.LoadFromEnv` populates `GME_*` env vars from the
+   configured provider (env / Vault Agent files — DSN-006).
+2. `config.Load` reads YAML + binds env via viper.
+3. `db.ConnectDb` opens the pgx pool and (optionally) runs
+   `migrate.Up`.
+4. `queue.NewInventoryQueue` and `queue.NewProductQueue` start
+   their redial loops; both threaded with the signal-aware
+   context so they unwind on shutdown.
+5. `user.Bootstrap` ensures an admin exists.
+6. `auth.NewSigner` constructs the JWT signer (with `strict=true`
+   in `prod`).
+7. The chi router is mounted; `srv.ListenAndServe` runs in a
+   goroutine.
+
+## Shutdown (DSN-001)
+
+`signal.NotifyContext(SIGINT, SIGTERM)` drives an ordered
+teardown. The shutdown deadline defaults to **30 seconds** and is
+overridable with `GME_SHUTDOWN_TIMEOUT_SECONDS` (positive integer,
+matching the `GME_JWT_TTL_SECONDS` pattern). Make sure the
+deadline stays **below** the orchestrator's grace period — for
+Kubernetes that's `terminationGracePeriodSeconds`, default 30s,
+so set both together if you change one.
+
+When a signal arrives:
+
+1. **HTTP** — `srv.Shutdown(timeoutCtx)` stops the listener and
+   waits for in-flight requests to finish. If the timeout
+   expires, `srv.Close()` drops remaining idle connections.
+2. **Database** — `pool.Close()` returns connections to Postgres
+   gracefully (pgxpool blocks until borrowed connections are
+   released).
+3. **Queue (deferred to TST-003)** — the redial loops in
+   [queue/queue.go](../queue/queue.go) cooperate with the cancelled
+   context, so `NewInventoryQueue` / `NewProductQueue` exit when
+   the next session boundary is reached. They do **not** yet
+   "finish in-flight deliveries then exit" — that's TST-003's
+   scope, since it requires the queue to grow a `Close` method
+   alongside the test suite.
+
+## Verifying graceful shutdown locally
+
+```sh
+# Terminal A
+make run
+
+# Terminal B — fire a slow-ish request, then Ctrl-C terminal A
+# while it's in flight. Expect the curl to return 200, not
+# "connection reset", and Terminal A should log
+# "HTTP server stopped cleanly" before exiting.
+curl -i http://localhost:8080/health
+```
+
+Automated coverage lives in
+[cmd/shutdown_test.go](../cmd/shutdown_test.go):
+
+- `TestShutdownHTTPDrainsInFlight` — request that's already
+  running when shutdown starts must complete with 200.
+- `TestShutdownHTTPHonorsDeadline` — a hanging request must not
+  block shutdown indefinitely; `Close()` falls back when the
+  deadline expires.
+- `TestResolveShutdownTimeout` — env-var parsing branches.
+
+## Known gaps
+
+- Queue consumer drain (see TST-003).
+- No structured "shutdown phase" metric. If you're debugging a
+  slow shutdown, the four `log.Info` lines emitted by
+  `shutdown` / `shutdownHTTP` are your timeline.


### PR DESCRIPTION
## Summary
Replaces the old \`log.Fatal().Err(srv.ListenAndServe())\` with the standard signal-driven graceful-shutdown pattern. In-flight HTTP requests now drain instead of getting RST'd; the pgx pool closes gracefully; queue redial loops see context cancellation.

- \`signal.NotifyContext(SIGINT, SIGTERM)\` produces a ctx that propagates through queue/db construction.
- \`srv.ListenAndServe\` runs in a goroutine; main blocks on either an early server error or the signal.
- \`shutdownHTTP\` runs \`srv.Shutdown(timeoutCtx)\` and falls back to \`srv.Close()\` on deadline-exceeded.
- Shutdown timeout defaults to **30s**, overridable via \`GME_SHUTDOWN_TIMEOUT_SECONDS\` (matches the existing \`GME_JWT_TTL_SECONDS\` env-var pattern).

## Tests
[cmd/shutdown_test.go](cmd/shutdown_test.go):
- \`TestShutdownHTTPDrainsInFlight\` — a request already running when shutdown starts must finish with 200; \`shutdownHTTP\` must return within its deadline.
- \`TestShutdownHTTPHonorsDeadline\` — a request that hangs past the deadline must not block shutdown; the \`Close\` fallback fires.
- \`TestResolveShutdownTimeout\` — env-var parsing branches.

## Docs
New [docs/lifecycle.md](docs/lifecycle.md): startup ordering, shutdown ordering, the "Ctrl-C with a curl in flight" verification recipe, the explicit warning to keep \`GME_SHUTDOWN_TIMEOUT_SECONDS\` below the orchestrator's grace period. Linked from the README's Contributing section.

## Out of scope (deferred to TST-003)
**AMQP consumer drain.** The redial loops in [queue/queue.go](queue/queue.go) already cooperate with ctx cancellation, but they don't expose a "finish in-flight deliveries then exit" surface. That needs the queue to grow a \`Close\` method, which sits more naturally alongside the queue test suite TST-003 establishes.

## Test plan
- [x] \`make verify\` clean locally
- [x] Three new shutdown tests pass
- [ ] CI matrix green on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)