### PR TITLE
DSN-002: split /health into /live and /ready

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	HealthEndpoint  = "/health"
-	MetricsEndpoint = "/metrics"
+	LivenessEndpoint  = "/live"
+	ReadinessEndpoint = "/ready"
+	MetricsEndpoint   = "/metrics"
 
 	ApiPath         = "/api/v1"
 	InventoryPath   = "/inventory"
@@ -29,8 +30,12 @@ const (
 	TokenPath       = "/token"
 )
 
-// ConfigureRouter instantiates a go-chi router with middleware and routes for the server
-func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc ReservationService, userService UserService, signer *auth.Signer) chi.Router {
+// ConfigureRouter instantiates a go-chi router with middleware and routes for the server.
+//
+// readinessDeps is the map of name → Pinger that /ready checks
+// on every probe. Callers pass at minimum {"db": pgPool}; pass
+// nil for an empty map (legacy tests).
+func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc ReservationService, userService UserService, signer *auth.Signer, readinessDeps map[string]Pinger) chi.Router {
 	log.Info().Msg("configuring router...")
 	r := chi.NewRouter()
 
@@ -48,10 +53,8 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Use(Logging)
 
-	r.HandleFunc(HealthEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("UP"))
-	})
+	r.Handle(LivenessEndpoint, LivenessHandler())
+	r.Handle(ReadinessEndpoint, ReadinessHandler(readinessDeps))
 	r.Handle(MetricsEndpoint, promhttp.Handler())
 
 	if signer != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -33,7 +33,7 @@ func newTestRouterWithSigner() (chi.Router, *user.MockUserService, *auth.Signer)
 	if err != nil {
 		panic(err)
 	}
-	return api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc, signer), usrSvc, signer
+	return api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc, signer, nil), usrSvc, signer
 }
 
 func TestCorsConfig(t *testing.T) {
@@ -136,7 +136,7 @@ func TestUnauthenticatedEndpointsRemainOpen(t *testing.T) {
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
-	openPaths := []string{api.HealthEndpoint, api.MetricsEndpoint}
+	openPaths := []string{api.LivenessEndpoint, api.ReadinessEndpoint, api.MetricsEndpoint}
 	for _, p := range openPaths {
 		res, err := http.Get(ts.URL + p)
 		if err != nil {

--- a/api/health.go
+++ b/api/health.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// readinessTimeout caps each downstream readiness check so the
+// probe itself cannot stall a Kubernetes kubelet (which retries
+// at periodSeconds and times out at timeoutSeconds; the probe
+// must return well inside both).
+const readinessTimeout = 1 * time.Second
+
+// Pinger is the minimal surface a downstream dependency needs to
+// expose for /ready to verify connectivity. *pgxpool.Pool
+// satisfies it directly via Ping(context.Context) error.
+//
+// Heavy queries don't belong here — the readiness probe runs on
+// every kubelet poll. A stdlib-style "Ping" is the contract.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// LivenessHandler returns 200 unconditionally. The process being
+// able to accept the request and reply at all is the liveness
+// signal; if pgx or AMQP are down, that's a *readiness* concern
+// (kubelet should stop sending traffic) not a *liveness* one
+// (kubelet should restart the pod).
+func LivenessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}
+}
+
+// ReadinessHandler returns 200 when every supplied Pinger pings
+// cleanly within readinessTimeout, 503 with a reason listing
+// failing dependencies otherwise. Each Pinger is checked
+// sequentially against its own per-check timeout context.
+//
+// AMQP is intentionally absent. The queue subsystem (queue/queue.go)
+// runs its own redial loop and does not currently expose a
+// non-blocking "are we connected?" query. Adding AMQP readiness
+// requires the queue to grow a state-watcher; tracked as a
+// follow-up to TST-003.
+func ReadinessHandler(deps map[string]Pinger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var failures []string
+		for name, dep := range deps {
+			ctx, cancel := context.WithTimeout(r.Context(), readinessTimeout)
+			err := dep.Ping(ctx)
+			cancel()
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					failures = append(failures, fmt.Sprintf("%s: timeout", name))
+				} else {
+					failures = append(failures, fmt.Sprintf("%s: %v", name, err))
+				}
+			}
+		}
+
+		if len(failures) > 0 {
+			log.Warn().Strs("failures", failures).Msg("readiness check failed")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			for _, f := range failures {
+				_, _ = fmt.Fprintln(w, f)
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}
+}

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -1,0 +1,143 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sksmith/go-micro-example/api"
+)
+
+type fakePinger struct {
+	err   error
+	delay time.Duration
+}
+
+func (f fakePinger) Ping(ctx context.Context) error {
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return f.err
+}
+
+func TestLivenessHandler(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.LivenessHandler()(rec, httptest.NewRequest(http.MethodGet, "/live", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status got=%d want=200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "OK" {
+		t.Errorf("body got=%q want=%q", got, "OK")
+	}
+}
+
+func TestReadinessHandlerHealthy(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.ReadinessHandler(map[string]api.Pinger{
+		"db": fakePinger{},
+	})(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status got=%d want=200", rec.Code)
+	}
+}
+
+func TestReadinessHandlerNoDeps(t *testing.T) {
+	// nil map should be safe (an empty readiness configuration
+	// is "always ready" — useful for tests and bootstrap).
+	rec := httptest.NewRecorder()
+	api.ReadinessHandler(nil)(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status got=%d want=200", rec.Code)
+	}
+}
+
+func TestReadinessHandlerFailingDep(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.ReadinessHandler(map[string]api.Pinger{
+		"db": fakePinger{err: errors.New("connection refused")},
+	})(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status got=%d want=503", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "db:") {
+		t.Errorf("body should name the failing dep, got %q", body)
+	}
+	if !strings.Contains(body, "connection refused") {
+		t.Errorf("body should include the error reason, got %q", body)
+	}
+}
+
+func TestReadinessHandlerSlowDepTimesOut(t *testing.T) {
+	// readinessTimeout is 1s; a 2s delay must trigger the
+	// deadline path and surface "timeout" in the body.
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	api.ReadinessHandler(map[string]api.Pinger{
+		"db": fakePinger{delay: 2 * time.Second},
+	})(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	elapsed := time.Since(start)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status got=%d want=503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "timeout") {
+		t.Errorf("body should classify timeout failures, got %q", rec.Body.String())
+	}
+	// The probe must return well inside the slow ping's duration —
+	// otherwise the probe itself would stall. Allow CI slack but
+	// the upper bound has to be < the 2s delay.
+	if elapsed >= 2*time.Second {
+		t.Errorf("readiness probe blocked for %s, exceeded its own timeout", elapsed)
+	}
+}
+
+func TestReadinessHandlerMultipleDepsAllReported(t *testing.T) {
+	rec := httptest.NewRecorder()
+	api.ReadinessHandler(map[string]api.Pinger{
+		"db":   fakePinger{err: errors.New("db down")},
+		"amqp": fakePinger{err: errors.New("amqp down")},
+	})(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status got=%d want=503", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "db:") || !strings.Contains(body, "amqp:") {
+		t.Errorf("body should list every failing dep, got %q", body)
+	}
+}
+
+// TestHealthEndpointsMounted is a small belt-and-braces test that
+// the router actually exposes /live and /ready. Catches a
+// regression where a refactor stops wiring one of them.
+func TestHealthEndpointsMounted(t *testing.T) {
+	r, _, _ := newTestRouterWithSigner()
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	for _, path := range []string{api.LivenessEndpoint, api.ReadinessEndpoint} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("%s: status got=%d want=200", path, resp.StatusCode)
+		}
+	}
+}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 
 	userService := user.NewService(ur)
 
-	r := api.ConfigureRouter(cfg, invService, invService, userService)
+	r := api.ConfigureRouter(cfg, invService, invService, userService, nil, map[string]api.Pinger{"db": dbPool})
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 func waitForReady() {
 	for {
-		res, err := http.Get(host() + "/health")
+		res, err := http.Get(host() + "/ready")
 		if err == nil && res.StatusCode == 200 {
 			break
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,7 +77,12 @@ func main() {
 
 	signer := configureSigner(cfg.Profile.Value)
 
-	r := api.ConfigureRouter(cfg, invService, invService, userService, signer)
+	// /ready pings every dep in this map on every probe.
+	// Pass at minimum the pgx pool. AMQP readiness is deliberately
+	// absent — the queue subsystem doesn't yet expose a non-blocking
+	// connectivity check; tracked alongside TST-003.
+	readinessDeps := map[string]api.Pinger{"db": dbPool}
+	r := api.ConfigureRouter(cfg, invService, invService, userService, signer, readinessDeps)
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -67,9 +67,35 @@ Automated coverage lives in
   deadline expires.
 - `TestResolveShutdownTimeout` — env-var parsing branches.
 
+## Health probes (DSN-002)
+
+The router exposes two endpoints for orchestrators to poll:
+
+| Endpoint  | Status | Purpose |
+|-----------|--------|---------|
+| `/live`  | always 200 | **Liveness.** The process is up enough to handle a request. Failing this means kubelet should restart the pod. Does not depend on any external system. |
+| `/ready` | 200 if every registered `Pinger` returns nil within 1s, 503 otherwise | **Readiness.** The pod is ready to accept traffic. Currently checks the pgx pool. AMQP is intentionally absent — the queue subsystem doesn't yet expose a non-blocking connectivity check (see follow-up). |
+
+Each `/ready` dep gets its own per-check 1s deadline so a wedged
+backend can't hang the probe past kubelet's `timeoutSeconds`.
+Failures are listed in the response body, one `name: reason` per
+line.
+
+### Configuring `/ready` deps
+
+`api.ConfigureRouter` takes a `map[string]api.Pinger` parameter.
+[cmd/main.go](../cmd/main.go) currently passes `{"db": dbPool}`;
+add new keys here as new external dependencies arrive (cache,
+search, etc.).
+
+`Pinger` is the minimal `Ping(ctx context.Context) error`
+interface — `*pgxpool.Pool` satisfies it directly.
+
 ## Known gaps
 
 - Queue consumer drain (see TST-003).
 - No structured "shutdown phase" metric. If you're debugging a
   slow shutdown, the four `log.Info` lines emitted by
   `shutdown` / `shutdownHTTP` are your timeline.
+- AMQP readiness — the queue's redial loop doesn't surface
+  connection state. Tracked alongside TST-003.


### PR DESCRIPTION
## Summary
The old \`/health\` was a tautology — 200 as long as the goroutine could reply, regardless of pgx / AMQP / anything else. Kubernetes treated it as both liveness *and* readiness, so a pod with a wedged DB connection still received traffic.

Replaces \`/health\` with two endpoints:
- **\`/live\`** — always 200. Process-up signal; failing means restart.
- **\`/ready\`** — 200 only when every registered dep pings cleanly within 1s; 503 with a \`name: reason\` body otherwise. Per-dep deadline so a wedged dep can't stall the probe past kubelet's \`timeoutSeconds\`.

\`/health\` is **removed**, not aliased — per the new "Treat this as a greenfield project" rule landed in \`plan/README.md\`.

## API surface
\`api.Pinger\` is the minimal \`Ping(ctx) error\` interface; \`*pgxpool.Pool\` satisfies it directly. \`ConfigureRouter\` grew a \`readinessDeps map[string]Pinger\` parameter so callers register what \`/ready\` checks. \`cmd/main.go\` passes \`{"db": dbPool}\`.

## Tests
[api/health_test.go](api/health_test.go) covers liveness, readiness happy path, nil-deps-map (always ready), failing dep (name + reason in body), slow dep with timeout reason (probe returns well under the dep's delay), multi-dep failure (every failing dep listed), and a belt-and-braces test that the router actually exposes both endpoints.

## Out of scope (TST-004)
**AMQP readiness.** The queue subsystem doesn't yet expose a non-blocking connectivity check. Filed [TST-004](plan/TST-004-amqp-readiness.md) — naturally pairs with TST-003.

## Other changes
- \`cmd/integration_test.go\` threaded for the new \`readinessDeps\` arg. Also caught a pre-existing miss — the file was already missing the SEC-002a \`signer\` arg under its \`//go:build integration\` tag; both fixed.
- \`docs/lifecycle.md\` gains a Health probes section with table + configuration notes.
- \`plan/README.md\` grew a "Treat this as a greenfield project" section codifying the no-backwards-compat rule.

## Test plan
- [x] \`make verify\` clean locally
- [x] Both build paths compile (default and \`-tags integration\`)
- [ ] CI matrix green on Linux/macOS/Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)