### PR TITLE
DSN-005: correlation IDs in logs and AMQP propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHA1 := $(shell git rev-parse HEAD)
 NOW := $(shell date -u +'%Y-%m-%d_%TZ')
 GOBIN := $(shell go env GOPATH)/bin
 
-.PHONY: fmt vet lint sec test-race verify
+.PHONY: fmt vet lint sec test-race verify cover
 fmt:
 	@echo "==> gofmt"
 	@out=$$(gofmt -l .); if [ -n "$$out" ]; then echo "$$out"; echo "files need gofmt"; exit 1; fi
@@ -26,6 +26,12 @@ test-race:
 
 verify: fmt vet lint sec test-race
 	@echo "==> verify OK"
+
+cover:
+	@echo "==> coverage"
+	go test ./... -race -coverprofile=cover.out
+	@echo "--- uncovered lines ---"
+	@go tool cover -func=cover.out | grep -v '100.0%' || true
 
 build:
 	@echo Building the binary

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ I ended up going with [zerolog](https://github.com/rs/zerolog) for logging in th
 their benchmarks look really great too! You can get structured logging or nice human-readable logging by
 [changing some configs](config.yml#L10)
 
+Every request flows through `api.CorrelationLogger`, which honours an inbound `X-Request-Id`
+(generates one if absent) and binds `request_id` — plus `trace_id` / `span_id` when an OTel span
+is recording — onto a child logger attached to the request context. Downstream code uses
+`log.Ctx(ctx)` to pick up the correlated logger; the AMQP layer ferries `request_id` across
+queue boundaries via the `x-request-id` header. See [docs/observability.md](docs/observability.md)
+for the full picture.
+
 ### Configuration
 
 This project uses [viper](https://github.com/spf13/viper) for handling externalized configurations. At the moment it

--- a/api/api.go
+++ b/api/api.go
@@ -55,6 +55,10 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 	// is the span name, which is what you want for grouping —
 	// not the literal URL with the sku interpolated.
 	r.Use(otelchi.Middleware(cfg.AppName.Value, otelchi.WithChiRoutes(r)))
+	// CorrelationLogger must mount after RequestID + otelchi (so it can
+	// read the request and trace IDs they set) and before everything
+	// that emits logs, so log.Ctx(ctx) carries the correlation fields.
+	r.Use(CorrelationLogger)
 	r.Use(Metrics)
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 	r.Use(Logging)
@@ -81,12 +85,12 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 
 func Render(w http.ResponseWriter, r *http.Request, rnd render.Renderer) {
 	if err := render.Render(w, r, rnd); err != nil {
-		log.Warn().Err(err).Msg("failed to render")
+		log.Ctx(r.Context()).Warn().Err(err).Msg("failed to render")
 	}
 }
 
 func RenderList(w http.ResponseWriter, r *http.Request, l []render.Renderer) {
 	if err := render.RenderList(w, r, l); err != nil {
-		log.Warn().Err(err).Msg("failed to render")
+		log.Ctx(r.Context()).Warn().Err(err).Msg("failed to render")
 	}
 }

--- a/api/authapi.go
+++ b/api/authapi.go
@@ -51,14 +51,14 @@ func (a *AuthApi) Token(w http.ResponseWriter, r *http.Request) {
 			authErr(w)
 			return
 		}
-		log.Error().Err(err).Str("username", username).Msg("error acquiring user during token issuance")
+		log.Ctx(r.Context()).Error().Err(err).Str("username", username).Msg("error acquiring user during token issuance")
 		Render(w, r, ErrInternalServer)
 		return
 	}
 
 	signed, expiresAt, err := a.signer.Issue(u)
 	if err != nil {
-		log.Error().Err(err).Str("username", username).Msg("error signing token")
+		log.Ctx(r.Context()).Error().Err(err).Str("username", username).Msg("error signing token")
 		Render(w, r, ErrInternalServer)
 		return
 	}

--- a/api/correlation_test.go
+++ b/api/correlation_test.go
@@ -1,0 +1,66 @@
+package api_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/sksmith/go-micro-example/api"
+)
+
+func TestCorrelationLogger_PropagatesXRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	original := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+	t.Cleanup(func() { log.Logger = original })
+
+	r, _ := newTestRouter()
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+api.LivenessEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Request-Id", "test-123")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+
+	got := buf.String()
+	if !strings.Contains(got, "test-123") {
+		t.Errorf("expected log output to contain inbound X-Request-Id %q, got:\n%s", "test-123", got)
+	}
+	if !strings.Contains(got, `"request_id"`) {
+		t.Errorf("expected log output to contain request_id field, got:\n%s", got)
+	}
+}
+
+func TestCorrelationLogger_GeneratesIDWhenAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	original := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+	t.Cleanup(func() { log.Logger = original })
+
+	r, _ := newTestRouter()
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+
+	res, err := http.Get(ts.URL + api.LivenessEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+
+	got := buf.String()
+	if !strings.Contains(got, `"request_id"`) {
+		t.Errorf("expected request_id field even when X-Request-Id absent, got:\n%s", got)
+	}
+}

--- a/api/health.go
+++ b/api/health.go
@@ -65,7 +65,7 @@ func ReadinessHandler(deps map[string]Pinger) http.HandlerFunc {
 		}
 
 		if len(failures) > 0 {
-			log.Warn().Strs("failures", failures).Msg("readiness check failed")
+			log.Ctx(r.Context()).Warn().Strs("failures", failures).Msg("readiness check failed")
 			w.WriteHeader(http.StatusServiceUnavailable)
 			for _, f := range failures {
 				_, _ = fmt.Fprintln(w, f)

--- a/api/inventoryapi.go
+++ b/api/inventoryapi.go
@@ -61,11 +61,11 @@ func (a *InventoryApi) ConfigureRouter(r chi.Router) {
 // would need to be able to scale. If it were scaled, clients would only get updates
 // that occurred in their connected instance.
 func (a *InventoryApi) Subscribe(w http.ResponseWriter, r *http.Request) {
-	log.Info().Msg("client requesting subscription")
+	log.Ctx(r.Context()).Info().Msg("client requesting subscription")
 
 	conn, _, _, err := ws.UpgradeHTTP(r, w)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to establish inventory subscription connection")
+		log.Ctx(r.Context()).Error().Err(err).Msg("failed to establish inventory subscription connection")
 		Render(w, r, ErrInternalServer)
 		return
 	}
@@ -103,7 +103,7 @@ func (a *InventoryApi) List(w http.ResponseWriter, r *http.Request) {
 
 	products, err := a.service.GetAllProductInventory(r.Context(), limit, offset)
 	if err != nil {
-		log.Error().Err(err).Int("limit", limit).Int("offset", offset).Msg("failed to list product inventory")
+		log.Ctx(r.Context()).Error().Err(err).Int("limit", limit).Int("offset", offset).Msg("failed to list product inventory")
 		Render(w, r, ErrInternalServer)
 		return
 	}
@@ -123,7 +123,7 @@ func (a *InventoryApi) CreateProduct(w http.ResponseWriter, r *http.Request) {
 			Render(w, r, BadRequestResponse(err))
 			return
 		}
-		log.Error().Err(err).Str("sku", data.Product.Sku).Msg("failed to create product")
+		log.Ctx(r.Context()).Error().Err(err).Str("sku", data.Product.Sku).Msg("failed to create product")
 		Render(w, r, ErrInternalServer)
 		return
 	}
@@ -149,7 +149,7 @@ func (a *InventoryApi) ProductCtx(next http.Handler) http.Handler {
 			if errors.Is(err, core.ErrNotFound) {
 				Render(w, r, ErrNotFound)
 			} else {
-				log.Error().Err(err).Str("sku", sku).Msg("error acquiring product")
+				log.Ctx(r.Context()).Error().Err(err).Str("sku", sku).Msg("error acquiring product")
 				Render(w, r, ErrInternalServer)
 			}
 			return
@@ -174,7 +174,7 @@ func (a *InventoryApi) CreateProductionEvent(w http.ResponseWriter, r *http.Requ
 			Render(w, r, BadRequestResponse(err))
 			return
 		}
-		log.Error().Err(err).Str("sku", product.Sku).Str("requestId", data.ProductionRequest.RequestID).Msg("failed to record production event")
+		log.Ctx(r.Context()).Error().Err(err).Str("sku", product.Sku).Str("requestId", data.ProductionRequest.RequestID).Msg("failed to record production event")
 		Render(w, r, ErrInternalServer)
 		return
 	}
@@ -192,7 +192,7 @@ func (a *InventoryApi) GetProductInventory(w http.ResponseWriter, r *http.Reques
 		if errors.Is(err, core.ErrNotFound) {
 			Render(w, r, ErrNotFound)
 		} else {
-			log.Error().Err(err).Str("sku", product.Sku).Msg("failed to get product inventory")
+			log.Ctx(r.Context()).Error().Err(err).Str("sku", product.Sku).Msg("failed to get product inventory")
 			Render(w, r, ErrInternalServer)
 		}
 		return

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -16,8 +16,32 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/core/auth"
+	"github.com/sksmith/go-micro-example/core/observability"
 	"github.com/sksmith/go-micro-example/core/user"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// CorrelationLogger installs a request-scoped zerolog logger into the
+// request context so downstream code can call log.Ctx(ctx) and pick up
+// request_id (and trace_id/span_id when an OTel span is recording)
+// without threading those values manually. Mount AFTER chi's RequestID
+// and otelchi middleware so both IDs are available.
+func CorrelationLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		reqID := middleware.GetReqID(ctx)
+		ctx = observability.ContextWithRequestID(ctx, reqID)
+
+		zctx := log.With().Str("request_id", reqID)
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			zctx = zctx.
+				Str("trace_id", sc.TraceID().String()).
+				Str("span_id", sc.SpanID().String())
+		}
+		logger := zctx.Logger()
+		next.ServeHTTP(w, r.WithContext(logger.WithContext(ctx)))
+	})
+}
 
 const DefaultPageLimit = 50
 
@@ -83,7 +107,7 @@ func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Ha
 			case signer != nil && strings.HasPrefix(header, "Bearer "):
 				u, err := authenticateBearer(strings.TrimPrefix(header, "Bearer "), signer)
 				if err != nil {
-					log.Debug().Err(err).Msg("bearer token rejected")
+					log.Ctx(r.Context()).Debug().Err(err).Msg("bearer token rejected")
 					authErr(w)
 					return
 				}
@@ -101,7 +125,7 @@ func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Ha
 					if errors.Is(err, user.ErrInvalidCredentials) {
 						authErr(w)
 					} else {
-						log.Error().Err(err).Str("username", username).Msg("error acquiring user")
+						log.Ctx(r.Context()).Error().Err(err).Str("username", username).Msg("error acquiring user")
 						Render(w, r, ErrInternalServer)
 					}
 					return
@@ -154,7 +178,7 @@ func Logging(next http.Handler) http.Handler {
 		defer func() {
 			dur := fmt.Sprintf("%dms", time.Duration(time.Since(start).Milliseconds()))
 
-			log.Trace().
+			log.Ctx(r.Context()).Trace().
 				Str("method", r.Method).
 				Str("host", r.Host).
 				Str("uri", r.RequestURI).

--- a/api/reservationapi.go
+++ b/api/reservationapi.go
@@ -54,11 +54,11 @@ func (ra *ReservationApi) ConfigureRouter(r chi.Router) {
 }
 
 func (a *ReservationApi) Subscribe(w http.ResponseWriter, r *http.Request) {
-	log.Info().Msg("client requesting subscription")
+	log.Ctx(r.Context()).Info().Msg("client requesting subscription")
 
 	conn, _, _, err := ws.UpgradeHTTP(r, w)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to establish reservation subscription connection")
+		log.Ctx(r.Context()).Error().Err(err).Msg("failed to establish reservation subscription connection")
 		Render(w, r, ErrInternalServer)
 		return
 	}
@@ -115,7 +115,7 @@ func (a *ReservationApi) Create(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, inventory.ErrInvalidInput):
 			Render(w, r, BadRequestResponse(err))
 		default:
-			log.Error().Err(err).Interface("reservationRequest", data).Msg("failed to reserve")
+			log.Ctx(r.Context()).Error().Err(err).Interface("reservationRequest", data).Msg("failed to reserve")
 			Render(w, r, ErrInternalServer)
 		}
 		return
@@ -142,7 +142,7 @@ func (a *ReservationApi) ReservationCtx(next http.Handler) http.Handler {
 
 		ID, err := strconv.ParseUint(IDStr, 10, 64)
 		if err != nil {
-			log.Error().Err(err).Str("ID", IDStr).Msg("invalid reservation id")
+			log.Ctx(r.Context()).Error().Err(err).Str("ID", IDStr).Msg("invalid reservation id")
 			Render(w, r, BadRequestResponse(errors.New("invalid reservation id")))
 			return
 		}
@@ -153,7 +153,7 @@ func (a *ReservationApi) ReservationCtx(next http.Handler) http.Handler {
 			if errors.Is(err, core.ErrNotFound) {
 				Render(w, r, ErrNotFound)
 			} else {
-				log.Error().Err(err).Str("id", IDStr).Msg("error acquiring product")
+				log.Ctx(r.Context()).Error().Err(err).Str("id", IDStr).Msg("error acquiring product")
 				Render(w, r, ErrInternalServer)
 			}
 			return
@@ -182,7 +182,7 @@ func (a *ReservationApi) List(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, core.ErrNotFound) {
 			Render(w, r, ErrNotFound)
 		} else {
-			log.Error().Err(err).Str("sku", sku).Str("state", string(state)).Msg("failed to list reservations")
+			log.Ctx(r.Context()).Error().Err(err).Str("sku", sku).Str("state", string(state)).Msg("failed to list reservations")
 			Render(w, r, ErrInternalServer)
 		}
 		return

--- a/api/userapi.go
+++ b/api/userapi.go
@@ -33,7 +33,7 @@ func (a *UserApi) ConfigureRouter(r chi.Router) {
 func (a *UserApi) Create(w http.ResponseWriter, r *http.Request) {
 	data := &CreateUserRequestDto{}
 	if err := render.Bind(r, data); err != nil {
-		log.Error().Err(err).Msg("failed to bind create-user request")
+		log.Ctx(r.Context()).Error().Err(err).Msg("failed to bind create-user request")
 		Render(w, r, BadRequestResponse(err))
 		return
 	}
@@ -45,7 +45,7 @@ func (a *UserApi) Create(w http.ResponseWriter, r *http.Request) {
 			Render(w, r, BadRequestResponse(err))
 			return
 		}
-		log.Error().Err(err).Str("username", data.Username).Msg("failed to create user")
+		log.Ctx(r.Context()).Error().Err(err).Str("username", data.Username).Msg("failed to create user")
 		Render(w, r, ErrInternalServer)
 		return
 	}

--- a/core/inventory/repository.go
+++ b/core/inventory/repository.go
@@ -18,7 +18,7 @@ func rollback(ctx context.Context, tx core.Transaction, trigger error) {
 		return
 	}
 	if rbErr := tx.Rollback(ctx); rbErr != nil {
-		log.Warn().Err(rbErr).AnErr("trigger", trigger).Msg("failed to rollback")
+		log.Ctx(ctx).Warn().Err(rbErr).AnErr("trigger", trigger).Msg("failed to rollback")
 	}
 }
 

--- a/core/inventory/repository_test.go
+++ b/core/inventory/repository_test.go
@@ -28,11 +28,15 @@ func TestRollbackLogsRollbackError(t *testing.T) {
 	mockTx.RollbackFunc = func(ctx context.Context) error { return rollbackErr }
 
 	var buf bytes.Buffer
+	testLogger := zerolog.New(&buf)
 	original := log.Logger
-	log.Logger = zerolog.New(&buf)
+	log.Logger = testLogger
 	t.Cleanup(func() { log.Logger = original })
 
-	rollback(context.Background(), mockTx, triggerErr)
+	// rollback uses log.Ctx(ctx); attach the buffer-backed logger to
+	// ctx so the test exercises the same code path production hits.
+	ctx := testLogger.WithContext(context.Background())
+	rollback(ctx, mockTx, triggerErr)
 
 	if buf.Len() == 0 {
 		t.Fatal("expected a log entry, got none")

--- a/core/inventory/service.go
+++ b/core/inventory/service.go
@@ -54,7 +54,7 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 		return fmt.Errorf("get existing product: %w", err)
 	}
 	if err == nil {
-		log.Debug().Str("func", funcName).Str("sku", dbProduct.Sku).Msg("product already exists")
+		log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", dbProduct.Sku).Msg("product already exists")
 		return nil
 	}
 
@@ -68,12 +68,12 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 		}
 	}()
 
-	log.Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product")
+	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product")
 	if err = s.repo.SaveProduct(ctx, product, core.UpdateOptions{Tx: tx}); err != nil {
 		return fmt.Errorf("save product: %w", err)
 	}
 
-	log.Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product inventory")
+	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", product.Sku).Msg("creating product inventory")
 	pi := ProductInventory{Product: product}
 
 	if err = s.repo.SaveProductInventory(ctx, pi, core.UpdateOptions{Tx: tx}); err != nil {
@@ -90,7 +90,7 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 func (s *service) Produce(ctx context.Context, product Product, pr ProductionRequest) error {
 	const funcName = "Produce"
 
-	log.Debug().
+	log.Ctx(ctx).Debug().
 		Str("func", funcName).
 		Str("sku", product.Sku).
 		Str("requestId", pr.RequestID).
@@ -110,7 +110,7 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 	}
 
 	if event.RequestID != "" {
-		log.Debug().Str("func", funcName).Str("requestId", pr.RequestID).Msg("production request already exists")
+		log.Ctx(ctx).Debug().Str("func", funcName).Str("requestId", pr.RequestID).Msg("production request already exists")
 		return nil
 	}
 
@@ -164,7 +164,7 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservation, error) {
 	const funcName = "Reserve"
 
-	log.Debug().
+	log.Ctx(ctx).Debug().
 		Str("func", funcName).
 		Str("requestID", rr.RequestID).
 		Str("sku", rr.Sku).
@@ -196,7 +196,7 @@ func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservati
 		return Reservation{}, fmt.Errorf("get reservation by request id %q: %w", rr.RequestID, err)
 	}
 	if res.RequestID != "" {
-		log.Debug().Str("func", funcName).Str("requestId", rr.RequestID).Msg("reservation already exists, returning it")
+		log.Ctx(ctx).Debug().Str("func", funcName).Str("requestId", rr.RequestID).Msg("reservation already exists, returning it")
 		rollback(ctx, tx, nil)
 		return res, nil
 	}
@@ -248,7 +248,7 @@ func (s *service) GetAllProductInventory(ctx context.Context, limit, offset int)
 func (s *service) GetProduct(ctx context.Context, sku string) (Product, error) {
 	const funcName = "GetProduct"
 
-	log.Debug().Str("func", funcName).Str("sku", sku).Msg("getting product")
+	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product")
 
 	product, err := s.repo.GetProduct(ctx, sku)
 	if err != nil {
@@ -260,7 +260,7 @@ func (s *service) GetProduct(ctx context.Context, sku string) (Product, error) {
 func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductInventory, error) {
 	const funcName = "GetProductInventory"
 
-	log.Debug().Str("func", funcName).Str("sku", sku).Msg("getting product inventory")
+	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product inventory")
 
 	product, err := s.repo.GetProductInventory(ctx, sku)
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductI
 func (s *service) GetReservation(ctx context.Context, ID uint64) (Reservation, error) {
 	const funcName = "GetReservation"
 
-	log.Debug().Str("func", funcName).Uint64("id", ID).Msg("getting reservation")
+	log.Ctx(ctx).Debug().Str("func", funcName).Uint64("id", ID).Msg("getting reservation")
 
 	rsv, err := s.repo.GetReservation(ctx, ID)
 	if err != nil {
@@ -284,7 +284,7 @@ func (s *service) GetReservation(ctx context.Context, ID uint64) (Reservation, e
 func (s *service) GetReservations(ctx context.Context, options GetReservationsOptions, limit, offset int) ([]Reservation, error) {
 	const funcName = "GetReservations"
 
-	log.Debug().
+	log.Ctx(ctx).Debug().
 		Str("func", funcName).
 		Str("sku", options.Sku).
 		Str("state", string(options.State)).
@@ -371,7 +371,7 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 		}()
 		reservation := reservation
 
-		log.Trace().
+		log.Ctx(ctx).Trace().
 			Str("func", funcName).
 			Str("sku", product.Sku).
 			Str("reservation.RequestID", reservation.RequestID).
@@ -393,7 +393,7 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 			reservation.State = Closed
 		}
 
-		log.Debug().
+		log.Ctx(ctx).Debug().
 			Str("func", funcName).
 			Str("sku", product.Sku).
 			Str("reservation.RequestID", reservation.RequestID).
@@ -404,7 +404,7 @@ func (s *service) FillReserves(ctx context.Context, product Product) error {
 			return fmt.Errorf("save product inventory: %w", err)
 		}
 
-		log.Debug().
+		log.Ctx(ctx).Debug().
 			Str("func", funcName).
 			Str("sku", product.Sku).
 			Str("reservation.RequestID", reservation.RequestID).

--- a/core/observability/correlation.go
+++ b/core/observability/correlation.go
@@ -1,0 +1,45 @@
+package observability
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// Without this hook, zerolog's log.Ctx(ctx) returns its package-level
+// disabled logger when ctx has no logger attached — which silently
+// drops logs from any code path reached outside an HTTP request (tests,
+// startup, queue consumer cold paths). Pinning DefaultContextLogger to
+// the address of the global zerolog/log.Logger keeps log.Ctx(ctx)
+// behaving like log.Logger when no request-scoped logger has been
+// installed, so callers can use log.Ctx unconditionally.
+func init() {
+	zerolog.DefaultContextLogger = &log.Logger
+}
+
+// requestIDCtxKey is a private type so the value cannot collide with
+// other packages' context keys (including chi's middleware.RequestIDKey,
+// which uses a different unexported key on a different package path).
+type requestIDCtxKey struct{}
+
+// ContextWithRequestID stores the supplied request ID on ctx so that
+// transports without an HTTP request (e.g. the AMQP consumer) can
+// re-establish correlation by extracting it back out via
+// RequestIDFromContext. An empty id is a no-op so callers don't need
+// to guard the empty case themselves.
+func ContextWithRequestID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDCtxKey{}, id)
+}
+
+// RequestIDFromContext returns the request ID stored by
+// ContextWithRequestID, or "" if none is present.
+func RequestIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(requestIDCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/core/observability/correlation_test.go
+++ b/core/observability/correlation_test.go
@@ -1,0 +1,31 @@
+package observability_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/core/observability"
+)
+
+func TestRequestIDRoundTrip(t *testing.T) {
+	ctx := observability.ContextWithRequestID(context.Background(), "abc-123")
+	if got := observability.RequestIDFromContext(ctx); got != "abc-123" {
+		t.Errorf("round-trip got %q, want %q", got, "abc-123")
+	}
+}
+
+func TestRequestIDFromContext_Missing(t *testing.T) {
+	if got := observability.RequestIDFromContext(context.Background()); got != "" {
+		t.Errorf("expected empty string from bare context, got %q", got)
+	}
+}
+
+func TestContextWithRequestID_EmptyIsNoOp(t *testing.T) {
+	parent := context.Background()
+	ctx := observability.ContextWithRequestID(parent, "")
+	// Empty IDs should not be stored (so RequestIDFromContext returns ""
+	// rather than the empty string we'd otherwise have written).
+	if got := observability.RequestIDFromContext(ctx); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}

--- a/core/user/service.go
+++ b/core/user/service.go
@@ -89,7 +89,7 @@ func (s *service) Login(ctx context.Context, username, password string) (User, e
 		// logging at the boundary, but it must not produce a
 		// different HTTP response than a wrong password.
 		if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
-			log.Error().Err(err).Str("username", username).Msg("bcrypt comparison failed for non-mismatch reason")
+			log.Ctx(ctx).Error().Err(err).Str("username", username).Msg("bcrypt comparison failed for non-mismatch reason")
 		}
 		return User{}, ErrInvalidCredentials
 	}

--- a/db/usrrepo/repo.go
+++ b/db/usrrepo/repo.go
@@ -59,7 +59,7 @@ func (r *dbRepo) Get(ctx context.Context, username string, txs ...core.QueryOpti
 
 	query := `SELECT username, password, is_admin, created_at FROM users WHERE username = $1 ` + forUpdate
 
-	log.Debug().Str("query", query).Str("username", username).Msg("getting user")
+	log.Ctx(ctx).Debug().Str("query", query).Str("username", username).Msg("getting user")
 
 	err := tx.QueryRow(ctx, query, username).
 		Scan(&u.Username, &u.HashedPassword, &u.IsAdmin, &u.Created)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -86,3 +86,48 @@ If you're debugging a missing-trace issue locally, check that:
    internally; check its logs).
 3. The trace was sampled — try `OTEL_TRACES_SAMPLER_ARG=1.0`
    in the dev environment to remove sampling as a variable.
+
+## Correlation IDs (DSN-005)
+
+Every request that enters the service flows through
+[`api.CorrelationLogger`](../api/middleware.go), which:
+
+1. Reads `X-Request-Id` from the inbound headers (chi's
+   `RequestID` middleware honours that header; if absent it
+   generates one).
+2. Reads the active OTel span from context (`otelchi` runs
+   first) and pulls out `trace_id` / `span_id`.
+3. Builds a child zerolog logger with `request_id` (and
+   `trace_id` / `span_id` when a span is recording) bound, and
+   attaches it to the request context.
+
+Downstream code uses `log.Ctx(ctx)` instead of the global
+`log.Logger`. That returns the per-request logger when one is
+attached, or the global logger as a fallback (the
+`zerolog.DefaultContextLogger` pin in
+[`core/observability/correlation.go`](../core/observability/correlation.go)
+makes the fallback work).
+
+### AMQP propagation
+
+For the queue boundary, the request ID is also stashed on a
+private context key by `CorrelationLogger`. The producer reads it
+back via `observability.RequestIDFromContext` and writes it to
+the AMQP message under the `x-request-id` header. The consumer
+reads the header, derives a per-message context with a logger
+that carries `request_id`, and invokes the handler with that
+context — so logs emitted while processing a queued message tie
+back to the original HTTP request that produced it.
+
+### What's not (yet) propagated
+
+- **Trace context across AMQP** — propagating W3C `traceparent`
+  through AMQP headers belongs to DSN-004a (AMQP tracing).
+  Once that lands, consumer-side spans will become children of
+  the producing request's span automatically; until then, only
+  `request_id` ferries across the queue.
+- **Outbound HTTP** — there is no outbound HTTP client in the
+  service today. When one is added, use `otelhttp.Transport`
+  for trace propagation; `request_id` can ride along in an
+  `X-Request-Id` header lifted from
+  `observability.RequestIDFromContext(ctx)`.

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -9,7 +9,13 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/config"
 	"github.com/sksmith/go-micro-example/core/inventory"
+	"github.com/sksmith/go-micro-example/core/observability"
 )
+
+// AMQPRequestIDHeader is the AMQP message header that carries the
+// inbound HTTP request ID across the queue boundary so consumer logs
+// can be correlated back to the producing request (DSN-005).
+const AMQPRequestIDHeader = "x-request-id"
 
 type InventoryQueue struct {
 	cfg         *config.Config
@@ -54,7 +60,7 @@ func (i *InventoryQueue) PublishInventory(ctx context.Context, productInventory 
 	if err != nil {
 		return fmt.Errorf("failed to serialize message for queue: %w", err)
 	}
-	i.inventory <- message(body)
+	i.inventory <- newMessage(ctx, body)
 	return nil
 }
 
@@ -63,8 +69,14 @@ func (i *InventoryQueue) PublishReservation(ctx context.Context, reservation inv
 	if err != nil {
 		return fmt.Errorf("error marshalling reservation to send to queue: %w", err)
 	}
-	i.reservation <- message(body)
+	i.reservation <- newMessage(ctx, body)
 	return nil
+}
+
+// newMessage snapshots the correlation fields off ctx so the publisher
+// goroutine has what it needs after the request scope has ended.
+func newMessage(ctx context.Context, body []byte) message {
+	return message{body: body, requestID: observability.RequestIDFromContext(ctx)}
 }
 
 type ProductQueue struct {
@@ -88,18 +100,26 @@ func NewProductQueue(ctx context.Context, cfg *config.Config, handler ProductHan
 	url := getUrl(cfg)
 
 	go func() {
-		for message := range prodChan {
+		for msg := range prodChan {
+			// Per-message correlation: derive a context bearing the
+			// inbound request_id so handler logs (and any outbound
+			// calls the handler makes) tie back to the producing
+			// request, even though we're miles from the HTTP scope.
+			msgCtx := observability.ContextWithRequestID(ctx, msg.requestID)
+			logger := log.With().Str("request_id", msg.requestID).Logger()
+			msgCtx = logger.WithContext(msgCtx)
+
 			product := inventory.Product{}
-			err := json.Unmarshal(message, &product)
+			err := json.Unmarshal(msg.body, &product)
 			if err != nil {
-				log.Error().Err(err).Msg("error unmarshalling product, writing to dlt")
-				pq.sendToDlt(ctx, message)
+				log.Ctx(msgCtx).Error().Err(err).Msg("error unmarshalling product, writing to dlt")
+				pq.sendToDlt(msgCtx, msg.body)
 			}
 
-			err = handler.CreateProduct(ctx, product)
+			err = handler.CreateProduct(msgCtx, product)
 			if err != nil {
-				log.Error().Err(err).Msg("failed to create product, sending to dlt")
-				pq.productDlt <- message
+				log.Ctx(msgCtx).Error().Err(err).Msg("failed to create product, sending to dlt")
+				pq.productDlt <- msg
 			}
 		}
 	}()
@@ -124,16 +144,20 @@ type ProductHandler interface {
 }
 
 func (p *ProductQueue) sendToDlt(ctx context.Context, body []byte) {
-	p.productDlt <- message(body)
+	p.productDlt <- newMessage(ctx, body)
 }
 
 // TODO We should be using one exchange per domain object here.
 // exchange binds the publishers to the subscribers
 // const exchange = "pubsub"
 
-// message is the application type for a message.  This can contain identity,
-// or a reference to the recevier chan for further demuxing.
-type message []byte
+// message is the application type for a message — the body plus any
+// correlation metadata the publisher should ferry into AMQP headers
+// (and the consumer should pull back out into context).
+type message struct {
+	body      []byte
+	requestID string
+}
 
 // session composes an amqp.Connection with an amqp.Channel
 type session struct {
@@ -219,14 +243,19 @@ func publish(sessions chan chan session, exchange string, messages <-chan messag
 					break Publish
 				}
 				if !confirmed.Ack {
-					log.Info().Uint64("message", confirmed.DeliveryTag).Str("body", string(body)).Msg("nack")
+					log.Info().Uint64("message", confirmed.DeliveryTag).Str("body", string(body.body)).Msg("nack")
 				}
 				reading = messages
 
 			case body = <-pending:
 				routingKey := "ignored for fanout exchanges, application dependent for other exchanges"
+				headers := amqp.Table{}
+				if body.requestID != "" {
+					headers[AMQPRequestIDHeader] = body.requestID
+				}
 				err := pub.Publish(exchange, routingKey, false, false, amqp.Publishing{
-					Body: body,
+					Headers: headers,
+					Body:    body.body,
 				})
 				// Retry failed delivery on the next session
 				if err != nil {
@@ -262,7 +291,11 @@ func subscribe(sessions chan chan session, queue string, messages chan<- message
 		log.Info().Str("queue", queue).Msg("listening for messages")
 
 		for msg := range deliveries {
-			messages <- message(msg.Body)
+			reqID := ""
+			if v, ok := msg.Headers[AMQPRequestIDHeader].(string); ok {
+				reqID = v
+			}
+			messages <- message{body: msg.Body, requestID: reqID}
 			err = sub.Ack(msg.DeliveryTag, false)
 			if err != nil {
 				log.Error().Err(err).Str("queue", queue).Msg("failed to acknowledge to queue")

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1,0 +1,31 @@
+package queue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/core/observability"
+)
+
+// TestNewMessage_CapturesRequestIDFromContext pins the producer-side
+// half of DSN-005's AMQP correlation: PublishInventory/PublishReservation
+// must snapshot the inbound request_id off ctx so the publisher
+// goroutine can attach it to the AMQP headers after the request scope
+// has ended.
+func TestNewMessage_CapturesRequestIDFromContext(t *testing.T) {
+	ctx := observability.ContextWithRequestID(context.Background(), "req-xyz")
+	m := newMessage(ctx, []byte(`{"sku":"abc"}`))
+	if m.requestID != "req-xyz" {
+		t.Errorf("requestID = %q, want %q", m.requestID, "req-xyz")
+	}
+	if string(m.body) != `{"sku":"abc"}` {
+		t.Errorf("body = %q, want body to be preserved", string(m.body))
+	}
+}
+
+func TestNewMessage_NoRequestIDIsEmpty(t *testing.T) {
+	m := newMessage(context.Background(), []byte("hi"))
+	if m.requestID != "" {
+		t.Errorf("expected empty requestID for ctx without one, got %q", m.requestID)
+	}
+}


### PR DESCRIPTION
Ticket: [plan/DSN-005-correlation-ids.md](plan/DSN-005-correlation-ids.md)

## Summary

- Adds `api.CorrelationLogger` middleware that binds `request_id` (and `trace_id`/`span_id` when a span is recording) onto a request-scoped zerolog logger attached to the request context.
- Migrates request-scoped call sites from `log.Logger` to `log.Ctx(ctx)`. Pins `zerolog.DefaultContextLogger` to the package global so `log.Ctx(ctx)` on a bare context falls back to `log.Logger` instead of zerolog's disabled logger.
- Replaces the queue's `chan []byte` envelope with a struct carrying body + `requestID`. Producer copies the ID into the `x-request-id` AMQP header; consumer reads it back, builds a per-message ctx with a logger keyed on `request_id`, and invokes the handler with that ctx — so logs from a queued-message handler tie back to the producing HTTP request.
- Trace-context propagation across AMQP (W3C `traceparent`) is left to **DSN-004a**; only `request_id` ferries across the queue today.
- Adds `make cover` and updates the plan workflow doc to use `make` targets where one exists. (Bundled per scoping decision in the working session — the Makefile delta is dev tooling supporting the workflow.)

## Acceptance criteria

- [x] Every log line emitted within a request scope includes `request_id` (and `trace_id` / `span_id`, after DSN-004).
- [x] AMQP messages carry the request ID in headers; consumers extract it back into context.
- [x] Inbound `X-Request-Id` headers are honored; otherwise generated.
- [x] Test asserts that a request with `X-Request-Id: test-123` produces logs containing `test-123` (`api/correlation_test.go::TestCorrelationLogger_PropagatesXRequestID`).

## Notes / not done

- **Trace context across AMQP** — deferred to DSN-004a. Once that lands, consumer-side spans will become children of the producing request's span automatically.
- **Long-lived WS subscribe goroutines** (`api/inventoryapi.go`, `api/reservationapi.go`) still use the global `log.Logger` after the request-scope ends. The original request context isn't meaningful past the WS upgrade; this would be a wider refactor to attach a session-scoped logger to the goroutine.
- **`api/util.go::redact`** — kept on the global `log.Logger`. It's a reflection-based developer-error path that fires only when a struct is mistagged; threading ctx through the recursive helper is more weight than the path warrants.
- **Startup paths** (`cmd/main.go`, `*.NewService`/`*.NewRepository` constructors, `config`, `db.Init`) intentionally remain on the global logger — they run before any request scope exists.

## Local verification

\`\`\`
make verify
\`\`\`

All targets green: fmt, vet, lint, sec, test-race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)