### PR TITLE
SEC-002c: remove Basic Auth from protected routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ RESTful API.
 ### Authentication
 
 Endpoints under `/api/v1` are protected by the
-[Authenticate middleware](api/middleware.go), which accepts **either** an HTTP Basic credential
-**or** a Bearer JWT (SEC-002a — both modes work in parallel; SEC-002c will retire Basic Auth once
-callers have migrated). Users are stored in the database with bcrypt-hashed passwords and locally
-cached using [golang-lru](https://github.com/hashicorp/golang-lru). In a production setting if I
-actually wanted caching I'd either use a remote cache like Redis, or a distributed local cache like
+[Authenticate middleware](api/middleware.go), which requires a Bearer JWT. Callers exchange
+credentials at `/auth/token` (the only endpoint that accepts HTTP Basic) for a short-lived JWT,
+then present that token on subsequent requests. Users are stored in the database with
+bcrypt-hashed passwords and locally cached using
+[golang-lru](https://github.com/hashicorp/golang-lru). In a production setting if I actually
+wanted caching I'd either use a remote cache like Redis, or a distributed local cache like
 groupcache to prevent stale or out of sync data.
 
 #### Getting a JWT
@@ -125,16 +126,14 @@ This application outputs prometheus metrics using middleware I plugged into the 
 locally check them out at [http://localhost:8080/metrics](http://localhost:8080/metrics). Every URL automatically
 gets a hit count and a latency metric added. You can find the configurations [here](api/middleware.go).
 
-In addition to the per-URL metrics, the auth middleware exposes two counters so you can track the
-SEC-002 migration from Basic Auth to JWTs:
+In addition to the per-URL metrics, the auth middleware exposes two counters:
 
 | Metric | Meaning |
 | --- | --- |
-| `auth_basic_requests_total` | Successful HTTP Basic Auth requests. |
+| `auth_basic_requests_total` | Retained from the SEC-002 migration; stays flat at zero now that Basic Auth is no longer accepted on protected routes (SEC-002c). |
 | `auth_jwt_requests_total` | Successful Bearer JWT requests. |
 
-Neither counter increments on auth failure. SEC-002c will remove the Basic Auth path once
-`rate(auth_basic_requests_total[1d])` is at zero across at least one release cycle.
+Neither counter increments on auth failure.
 
 ### Logging
 

--- a/api/api.go
+++ b/api/api.go
@@ -71,7 +71,7 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 		r.Route(AuthPath, NewAuthApi(userService, signer).ConfigureRouter)
 	}
 
-	r.With(Authenticate(userService, signer)).Route(ApiPath, func(r chi.Router) {
+	r.With(Authenticate(signer)).Route(ApiPath, func(r chi.Router) {
 		r.Route(InventoryPath, NewInventoryApi(invSvc).ConfigureRouter)
 		r.Route(ReservationPath, NewReservationApi(resSvc).ConfigureRouter)
 		r.Route(UserPath, NewUserApi(userService).ConfigureRouter)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -113,7 +114,8 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 			}
 		})
 
-		t.Run("bad-credentials/"+test.name, func(t *testing.T) {
+		t.Run("basic-auth-rejected/"+test.name, func(t *testing.T) {
+			// SEC-002c: Basic Auth is no longer accepted on protected routes.
 			req, err := http.NewRequest(http.MethodGet, ts.URL+test.path, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -125,7 +127,10 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 			}
 			defer res.Body.Close()
 			if res.StatusCode != http.StatusUnauthorized {
-				t.Errorf("expected 401 for bad-credentials %s, got %d", test.path, res.StatusCode)
+				t.Errorf("expected 401 for Basic-Auth attempt on %s, got %d", test.path, res.StatusCode)
+			}
+			if got := res.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Bearer") {
+				t.Errorf("expected WWW-Authenticate: Bearer on %s, got %q", test.path, got)
 			}
 		})
 	}

--- a/api/auth_metrics_test.go
+++ b/api/auth_metrics_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/sksmith/go-micro-example/api"
-	"github.com/sksmith/go-micro-example/core"
 	"github.com/sksmith/go-micro-example/core/user"
 )
 
@@ -44,13 +42,10 @@ func readCounter(t *testing.T, ts *httptest.Server, name string) float64 {
 }
 
 func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
-	r, usrSvc, signer := newTestRouterWithSigner()
-	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
-		if username == "alice" && password == "pw" {
-			return user.User{Username: "alice", IsAdmin: true}, nil
-		}
-		return user.User{}, core.ErrNotFound
-	}
+	// SEC-002c: Basic Auth is rejected on protected routes, so
+	// auth_basic_requests_total never increments. The counter is
+	// retained for migration visibility and must stay flat at zero.
+	r, _, signer := newTestRouterWithSigner()
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
@@ -60,7 +55,7 @@ func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
 		t.Fatalf("expected counters to exist, basic=%v jwt=%v", basicBefore, jwtBefore)
 	}
 
-	// Successful Basic Auth → basic counter should advance, jwt should not.
+	// Basic Auth attempt → rejected with 401, no counter movement.
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
 	req.SetBasicAuth("alice", "pw")
 	res, err := http.DefaultClient.Do(req)
@@ -68,40 +63,34 @@ func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Basic Auth attempt should be 401, got %d", res.StatusCode)
+	}
 
-	// Failed Basic Auth → no counter movement.
+	// Successful Bearer → jwt counter should advance, basic should not.
+	tok, _, _ := signer.Issue(user.User{Username: "alice", IsAdmin: true})
 	req2, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
-	req2.SetBasicAuth("alice", "wrong")
+	req2.Header.Set("Authorization", "Bearer "+tok)
 	res2, err := http.DefaultClient.Do(req2)
 	if err != nil {
 		t.Fatal(err)
 	}
 	res2.Body.Close()
 
-	// Successful Bearer → jwt counter should advance, basic should not.
-	tok, _, _ := signer.Issue(user.User{Username: "alice", IsAdmin: true})
+	// Failed Bearer → no counter movement.
 	req3, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
-	req3.Header.Set("Authorization", "Bearer "+tok)
+	req3.Header.Set("Authorization", "Bearer not-a-real-token")
 	res3, err := http.DefaultClient.Do(req3)
 	if err != nil {
 		t.Fatal(err)
 	}
 	res3.Body.Close()
 
-	// Failed Bearer → no counter movement.
-	req4, _ := http.NewRequest(http.MethodGet, ts.URL+api.ApiPath+api.InventoryPath, nil)
-	req4.Header.Set("Authorization", "Bearer not-a-real-token")
-	res4, err := http.DefaultClient.Do(req4)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res4.Body.Close()
-
 	basicAfter := readCounter(t, ts, "auth_basic_requests_total")
 	jwtAfter := readCounter(t, ts, "auth_jwt_requests_total")
 
-	if basicAfter-basicBefore != 1 {
-		t.Errorf("auth_basic_requests_total moved by %v, want 1", basicAfter-basicBefore)
+	if basicAfter-basicBefore != 0 {
+		t.Errorf("auth_basic_requests_total moved by %v, want 0 post-SEC-002c", basicAfter-basicBefore)
 	}
 	if jwtAfter-jwtBefore != 1 {
 		t.Errorf("auth_jwt_requests_total moved by %v, want 1", jwtAfter-jwtBefore)

--- a/api/authapi.go
+++ b/api/authapi.go
@@ -12,8 +12,9 @@ import (
 	"github.com/sksmith/go-micro-example/core/auth"
 )
 
-// AuthApi exposes the /auth/token exchange (SEC-002a). Callers POST
-// HTTP Basic credentials and receive a short-lived bearer JWT.
+// AuthApi exposes the /auth/token exchange. Callers POST HTTP Basic
+// credentials and receive a short-lived bearer JWT — the only accepted
+// credential on protected routes after SEC-002c.
 type AuthApi struct {
 	users  UserService
 	signer *auth.Signer
@@ -41,14 +42,14 @@ func (a *AuthApi) ConfigureRouter(r chi.Router) {
 func (a *AuthApi) Token(w http.ResponseWriter, r *http.Request) {
 	username, password, ok := r.BasicAuth()
 	if !ok {
-		authErr(w)
+		basicAuthErr(w)
 		return
 	}
 
 	u, err := a.users.Login(r.Context(), username, password)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
-			authErr(w)
+			basicAuthErr(w)
 			return
 		}
 		log.Ctx(r.Context()).Error().Err(err).Str("username", username).Msg("error acquiring user during token issuance")

--- a/api/authapi_test.go
+++ b/api/authapi_test.go
@@ -156,8 +156,8 @@ func TestProtectedRouteRejectsTamperedBearer(t *testing.T) {
 	}
 }
 
-func TestProtectedRouteStillAcceptsBasicAuth(t *testing.T) {
-	// SEC-002a is additive — Basic Auth must keep working until SEC-002c.
+func TestProtectedRouteRejectsBasicAuth(t *testing.T) {
+	// SEC-002c: Basic Auth is no longer accepted on protected routes.
 	r, usrSvc, _ := newTestRouterWithSigner()
 	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
 		if username == "alice" && password == "pw" {
@@ -175,8 +175,11 @@ func TestProtectedRouteStillAcceptsBasicAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	res.Body.Close()
-	if res.StatusCode == http.StatusUnauthorized {
-		t.Errorf("expected basic auth to still work, got 401")
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 for Basic-Auth attempt, got %d", res.StatusCode)
+	}
+	if got := res.Header.Get("WWW-Authenticate"); !strings.HasPrefix(got, "Bearer") {
+		t.Errorf("expected WWW-Authenticate: Bearer, got %q", got)
 	}
 }
 

--- a/api/environmentapi_test.go
+++ b/api/environmentapi_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -87,20 +86,21 @@ func TestEnvEndpointRedactsSensitiveValues(t *testing.T) {
 }
 
 func TestEnvEndpointRequiresAdmin(t *testing.T) {
-	r, usrSvc := newTestRouter()
-	usrSvc.LoginFunc = func(ctx context.Context, username, password string) (user.User, error) {
-		return user.User{Username: "regular", IsAdmin: false}, nil
-	}
+	r, _, signer := newTestRouterWithSigner()
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
 	envURL := ts.URL + api.ApiPath + api.AdminPath + api.EnvPath
 
+	tok, _, err := signer.Issue(user.User{Username: "regular", IsAdmin: false})
+	if err != nil {
+		t.Fatal(err)
+	}
 	req, err := http.NewRequest(http.MethodGet, envURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.SetBasicAuth("regular", "pw")
+	req.Header.Set("Authorization", "Bearer "+tok)
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -82,58 +81,29 @@ func Paginate(next http.Handler) http.Handler {
 	})
 }
 
-type UserAccess interface {
-	Login(ctx context.Context, username, password string) (user.User, error)
-}
-
-// Authenticate accepts either an HTTP Basic credential or a Bearer JWT
-// (SEC-002a). Both modes populate CtxKeyUser. SEC-002c will remove the
-// Basic Auth path once usage is at zero.
+// Authenticate requires a Bearer JWT (SEC-002c). HTTP Basic credentials
+// are no longer accepted on protected routes; callers must exchange
+// credentials at /auth/token (SEC-002a) and present the issued JWT.
 //
-// signer may be nil, in which case only Basic Auth is accepted.
-//
-// The header decides which path runs: a request that says "Bearer ..."
-// is never tried as Basic, even if the JWT is malformed — so a typo'd
-// JWT does not silently degrade to a 401-from-missing-Basic-creds.
-func Authenticate(ua UserAccess, signer *auth.Signer) func(http.Handler) http.Handler {
-	// Ensure the auth counters exist even if Metrics() never runs first
-	// (defensive — in normal wiring Metrics() is registered before
-	// Authenticate, but tests sometimes mount Authenticate alone).
+// Bcrypt now runs only on the token-issue path.
+func Authenticate(signer *auth.Signer) func(http.Handler) http.Handler {
 	metricsOnce.Do(initMetrics)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			header := r.Header.Get("Authorization")
-			switch {
-			case signer != nil && strings.HasPrefix(header, "Bearer "):
-				u, err := authenticateBearer(strings.TrimPrefix(header, "Bearer "), signer)
-				if err != nil {
-					log.Ctx(r.Context()).Debug().Err(err).Msg("bearer token rejected")
-					authErr(w)
-					return
-				}
-				authJWTCounter.Inc()
-				ctx := context.WithValue(r.Context(), CtxKeyUser, u)
-				next.ServeHTTP(w, r.WithContext(ctx))
-			default:
-				username, password, ok := r.BasicAuth()
-				if !ok {
-					authErr(w)
-					return
-				}
-				u, err := ua.Login(r.Context(), username, password)
-				if err != nil {
-					if errors.Is(err, user.ErrInvalidCredentials) {
-						authErr(w)
-					} else {
-						log.Ctx(r.Context()).Error().Err(err).Str("username", username).Msg("error acquiring user")
-						Render(w, r, ErrInternalServer)
-					}
-					return
-				}
-				authBasicCounter.Inc()
-				ctx := context.WithValue(r.Context(), CtxKeyUser, u)
-				next.ServeHTTP(w, r.WithContext(ctx))
+			if signer == nil || !strings.HasPrefix(header, "Bearer ") {
+				authErr(w)
+				return
 			}
+			u, err := authenticateBearer(strings.TrimPrefix(header, "Bearer "), signer)
+			if err != nil {
+				log.Ctx(r.Context()).Debug().Err(err).Msg("bearer token rejected")
+				authErr(w)
+				return
+			}
+			authJWTCounter.Inc()
+			ctx := context.WithValue(r.Context(), CtxKeyUser, u)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
@@ -166,6 +136,11 @@ func AdminOnly(next http.Handler) http.Handler {
 }
 
 func authErr(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="restricted"`)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}
+
+func basicAuthErr(w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", `Basic realm="restricted", charset="UTF-8"`)
 	http.Error(w, "Unauthorized", http.StatusUnauthorized)
 }
@@ -221,7 +196,7 @@ func initMetrics() {
 
 	authBasicCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "auth_basic_requests_total",
-		Help: "Number of requests authenticated via HTTP Basic Auth. Tracked per SEC-002b so SEC-002c can remove the Basic Auth path when this rate drops to zero.",
+		Help: "Successful HTTP Basic Auth requests. Retained post-SEC-002c for migration visibility; expected to stay flat at zero since Basic Auth is no longer accepted on protected routes.",
 	})
 	authJWTCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "auth_jwt_requests_total",

--- a/api/userapi_test.go
+++ b/api/userapi_test.go
@@ -9,17 +9,21 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/sksmith/go-micro-example/api"
+	"github.com/sksmith/go-micro-example/core/auth"
 	"github.com/sksmith/go-micro-example/core/user"
 	"github.com/sksmith/go-micro-example/testutil"
 )
 
 func TestUserCreate(t *testing.T) {
-	ts, mockSvc := setupUserTestServer()
+	ts, mockSvc, signer := setupUserTestServer(t)
 	defer ts.Close()
+
+	adminTok := issueToken(t, signer, "someadmin", true)
+	nonAdminTok := issueToken(t, signer, "someuser", false)
 
 	tests := []struct {
 		name           string
-		loginFunc      func(ctx context.Context, username, password string) (user.User, error)
+		token          string
 		createFunc     func(ctx context.Context, user user.CreateUserRequest) (user.User, error)
 		url            string
 		request        interface{}
@@ -27,10 +31,8 @@ func TestUserCreate(t *testing.T) {
 		wantStatusCode int
 	}{
 		{
-			name: "admin users can create valid user",
-			loginFunc: func(ctx context.Context, username, password string) (user.User, error) {
-				return createUser("someadmin", "", true), nil
-			},
+			name:  "admin users can create valid user",
+			token: adminTok,
 			createFunc: func(ctx context.Context, usr user.CreateUserRequest) (user.User, error) {
 				return createUser(usr.Username, "somepasswordhash", usr.IsAdmin), nil
 			},
@@ -40,10 +42,8 @@ func TestUserCreate(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 		},
 		{
-			name: "non-admin users are unable to create users",
-			loginFunc: func(ctx context.Context, username, password string) (user.User, error) {
-				return createUser("someadmin", "", false), nil
-			},
+			name:  "non-admin users are unable to create users",
+			token: nonAdminTok,
 			createFunc: func(ctx context.Context, usr user.CreateUserRequest) (user.User, error) {
 				return createUser(usr.Username, "somepasswordhash", usr.IsAdmin), nil
 			},
@@ -53,34 +53,26 @@ func TestUserCreate(t *testing.T) {
 			wantStatusCode: http.StatusUnauthorized,
 		},
 		{
-			name: "when the creating user has invalid credentials, server returns unauthorized",
-			loginFunc: func(ctx context.Context, username, password string) (user.User, error) {
-				return user.User{}, user.ErrInvalidCredentials
-			},
-			createFunc: func(ctx context.Context, usr user.CreateUserRequest) (user.User, error) {
-				return createUser(usr.Username, "somepasswordhash", usr.IsAdmin), nil
-			},
-			url:            ts.URL,
-			request:        createUserReq("someuser", "somepass", false),
-			wantResponse:   nil,
-			wantStatusCode: http.StatusUnauthorized,
-		},
-		{
-			name: "when an unexpected error occurs logging in, an internal server error is returned",
-			loginFunc: func(ctx context.Context, username, password string) (user.User, error) {
-				return user.User{}, errors.New("some unexpected error")
-			},
+			name:           "requests without a bearer token are rejected",
+			token:          "",
 			createFunc:     nil,
 			url:            ts.URL,
 			request:        createUserReq("someuser", "somepass", false),
-			wantResponse:   api.ErrInternalServer,
-			wantStatusCode: http.StatusInternalServerError,
+			wantResponse:   nil,
+			wantStatusCode: http.StatusUnauthorized,
 		},
 		{
-			name: "when an error occurs creating the user, an internal server error is returned",
-			loginFunc: func(ctx context.Context, username, password string) (user.User, error) {
-				return createUser("someadmin", "", true), nil
-			},
+			name:           "requests with a tampered bearer token are rejected",
+			token:          adminTok + "tamper",
+			createFunc:     nil,
+			url:            ts.URL,
+			request:        createUserReq("someuser", "somepass", false),
+			wantResponse:   nil,
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name:  "when an error occurs creating the user, an internal server error is returned",
+			token: adminTok,
 			createFunc: func(ctx context.Context, usr user.CreateUserRequest) (user.User, error) {
 				return user.User{}, errors.New("some unexpected error")
 			},
@@ -93,10 +85,9 @@ func TestUserCreate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockSvc.LoginFunc = test.loginFunc
 			mockSvc.CreateFunc = test.createFunc
 
-			res := testutil.Post(test.url, test.request, t, testutil.RequestOptions{Username: "someuser", Password: "somepass"})
+			res := testutil.Post(test.url, test.request, t, testutil.RequestOptions{Token: test.token})
 
 			if res.StatusCode != test.wantStatusCode {
 				t.Errorf("status code got=%d want=%d", res.StatusCode, test.wantStatusCode)
@@ -129,14 +120,28 @@ func createUserReq(username, password string, isAdmin bool) api.CreateUserReques
 	return api.CreateUserRequestDto{CreateUserRequest: &user.CreateUserRequest{Username: username, IsAdmin: isAdmin}, Password: password}
 }
 
-func setupUserTestServer() (*httptest.Server, *user.MockUserService) {
+func setupUserTestServer(t *testing.T) (*httptest.Server, *user.MockUserService, *auth.Signer) {
+	t.Helper()
 	svc := user.NewMockUserService()
 	usrApi := api.NewUserApi(svc)
+	signer, err := auth.NewSigner(nil, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	r := chi.NewRouter()
-	r.With(api.Authenticate(svc, nil)).Route("/", func(r chi.Router) {
+	r.With(api.Authenticate(signer)).Route("/", func(r chi.Router) {
 		usrApi.ConfigureRouter(r)
 	})
 	ts := httptest.NewServer(r)
 
-	return ts, svc
+	return ts, svc, signer
+}
+
+func issueToken(t *testing.T, signer *auth.Signer, username string, isAdmin bool) string {
+	t.Helper()
+	tok, _, err := signer.Issue(user.User{Username: username, IsAdmin: isAdmin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
 }

--- a/testutil/http_util.go
+++ b/testutil/http_util.go
@@ -23,8 +23,7 @@ func Unmarshal(res *http.Response, v interface{}, t *testing.T) {
 }
 
 type RequestOptions struct {
-	Username string
-	Password string
+	Token string
 }
 
 func Put(url string, request interface{}, t *testing.T, op ...RequestOptions) *http.Response {
@@ -46,8 +45,8 @@ func SendRequest(method, url string, request interface{}, t *testing.T, op ...Re
 		t.Fatal(err)
 	}
 
-	if len(op) > 0 {
-		req.SetBasicAuth(op[0].Username, op[0].Password)
+	if len(op) > 0 && op[0].Token != "" {
+		req.Header.Set("Authorization", "Bearer "+op[0].Token)
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
## Summary

- `Authenticate` middleware now requires a Bearer JWT. Basic Auth on `/api/v1/*` returns 401 with `WWW-Authenticate: Bearer`.
- `/auth/token` still accepts Basic (RFC 6749 §2.3.1 client/credential exchange); bcrypt runs only on token issuance.
- `auth_basic_requests_total` counter retained for visibility — expected to stay flat at zero now that Basic Auth is rejected upstream of the success path.

## Acceptance criteria (from [plan/SEC-002c-deprecate-basic-auth.md](plan/SEC-002c-deprecate-basic-auth.md))

- [x] `Authenticate` rejects `Authorization: Basic ...` with 401 + `WWW-Authenticate: Bearer`.
- [x] `auth_basic_requests_total` left in place, expected flat at zero.
- [x] README updated to remove Basic Auth references; only `/auth/token` flow remains.
- [x] Tests updated: every Basic-Auth assertion flipped to expect 401.

## Notes

- `testutil.RequestOptions` switched from `{Username, Password}` to `{Token}` to match the new Bearer-only seam. Only consumer was `api/userapi_test.go`.
- `Authenticate` signature changed from `Authenticate(ua UserAccess, signer *auth.Signer)` to `Authenticate(signer *auth.Signer)`. The unused `UserAccess` interface was removed.
- Per `plan/README.md` greenfield posture, no deprecation aliases were added — Basic Auth on protected routes is gone, not 426'd.

## Test plan

- [x] `make verify` (fmt + vet + lint + sec + test-race) green locally.
- [x] `go test ./...` green.
- [ ] govulncheck — pre-existing findings in stdlib + deps, not introduced by this change. Out of scope; tracked separately under DEP-011/SEC-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)