### PR TITLE
DSN-011: shared, validated pagination contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ exactly. I couldn't quite find an equivalent solution I liked.
 Truth be told, if I were doing inter-microservice communication I would strongly consider using gRPC rather than a 
 RESTful API.
 
+#### Pagination
+
+List endpoints accept `?limit=…&offset=…`. `limit` defaults to `50`,
+must be a positive integer, and is capped at `200`. `offset` defaults
+to `0` and must be a non-negative integer. Invalid input returns a
+`400 application/problem+json` with an `errors[]` extension naming the
+offending field — values are never silently coerced.
+
+Responses include an [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288)
+`Link` header. A `rel="next"` link is emitted when the server returned
+a full page (`len(results) == limit`); a `rel="prev"` link is emitted
+when `offset > 0`.
+
 ### Authentication
 
 Endpoints under `/api/v1` are protected by the

--- a/api/inventoryapi.go
+++ b/api/inventoryapi.go
@@ -98,16 +98,16 @@ func (a *InventoryApi) Subscribe(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *InventoryApi) List(w http.ResponseWriter, r *http.Request) {
-	limit := r.Context().Value(CtxKeyLimit).(int)
-	offset := r.Context().Value(CtxKeyOffset).(int)
+	p := PaginationFrom(r.Context())
 
-	products, err := a.service.GetAllProductInventory(r.Context(), limit, offset)
+	products, err := a.service.GetAllProductInventory(r.Context(), p.Limit, p.Offset)
 	if err != nil {
-		log.Ctx(r.Context()).Error().Err(err).Int("limit", limit).Int("offset", offset).Msg("failed to list product inventory")
+		log.Ctx(r.Context()).Error().Err(err).Int("limit", p.Limit).Int("offset", p.Offset).Msg("failed to list product inventory")
 		Render(w, r, InternalServerProblem(err))
 		return
 	}
 
+	WriteLinkHeader(w, r, p, len(products))
 	RenderList(w, r, NewProductListResponse(products))
 }
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,44 +41,9 @@ func CorrelationLogger(next http.Handler) http.Handler {
 	})
 }
 
-const DefaultPageLimit = 50
-
 type CtxKey string
 
-const (
-	CtxKeyLimit  CtxKey = "limit"
-	CtxKeyOffset CtxKey = "offset"
-	CtxKeyUser   CtxKey = "user"
-)
-
-func Paginate(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		limitStr := r.URL.Query().Get("limit")
-		offsetStr := r.URL.Query().Get("offset")
-
-		var err error
-		limit := DefaultPageLimit
-		if limitStr != "" {
-			limit, err = strconv.Atoi(limitStr)
-			if err != nil {
-				limit = DefaultPageLimit
-			}
-		}
-
-		offset := 0
-		if offsetStr != "" {
-			offset, err = strconv.Atoi(offsetStr)
-			if err != nil {
-				offset = 0
-			}
-		}
-
-		ctx := context.WithValue(r.Context(), CtxKeyLimit, limit)
-		ctx = context.WithValue(ctx, CtxKeyOffset, offset)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
+const CtxKeyUser CtxKey = "user"
 
 // Authenticate requires a Bearer JWT (SEC-002c). HTTP Basic credentials
 // are no longer accepted on protected routes; callers must exchange

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Pagination is the validated representation of `?limit=…&offset=…`
+// that list handlers receive. DSN-011 made this typed and explicit
+// instead of stashing raw ints under string-keyed context values.
+type Pagination struct {
+	Limit  int
+	Offset int
+}
+
+const (
+	DefaultPageLimit = 50
+	MaxPageLimit     = 200
+)
+
+type pageCtxKey struct{}
+
+// Paginate validates `limit` and `offset` query params. Invalid input
+// is rejected with an RFC 7807 problem+json 400 — callers no longer
+// receive silently-coerced defaults (which used to mask client bugs).
+func Paginate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, problem := parsePagination(r.URL.Query())
+		if problem != nil {
+			Render(w, r, problem)
+			return
+		}
+		ctx := context.WithValue(r.Context(), pageCtxKey{}, p)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// PaginationFrom retrieves the validated Pagination set by Paginate.
+// Returns the zero/default value when the middleware was not mounted,
+// so handlers in non-paginated routes still get sane defaults if they
+// reach for it.
+func PaginationFrom(ctx context.Context) Pagination {
+	if p, ok := ctx.Value(pageCtxKey{}).(Pagination); ok {
+		return p
+	}
+	return Pagination{Limit: DefaultPageLimit}
+}
+
+func parsePagination(q url.Values) (Pagination, *Problem) {
+	p := Pagination{Limit: DefaultPageLimit}
+	var fields []FieldProblem
+
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		switch {
+		case err != nil, n < 1:
+			fields = append(fields, FieldProblem{Field: "limit", Detail: "must be a positive integer"})
+		case n > MaxPageLimit:
+			fields = append(fields, FieldProblem{Field: "limit", Detail: fmt.Sprintf("must be ≤ %d", MaxPageLimit)})
+		default:
+			p.Limit = n
+		}
+	}
+
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			fields = append(fields, FieldProblem{Field: "offset", Detail: "must be a non-negative integer"})
+		} else {
+			p.Offset = n
+		}
+	}
+
+	if len(fields) > 0 {
+		return Pagination{}, ValidationProblem(fields...)
+	}
+	return p, nil
+}
+
+// WriteLinkHeader emits an RFC 8288 Link header with `next` and `prev`
+// rels for offset-based pagination. `returnedCount` is the size of the
+// page actually served; when it equals limit, a `next` link is added
+// (we can't know without counting whether more truly exist, but
+// returning a full page is the conventional signal that another page
+// is probably available).
+func WriteLinkHeader(w http.ResponseWriter, r *http.Request, p Pagination, returnedCount int) {
+	var links []string
+
+	if returnedCount == p.Limit {
+		links = append(links, formatLink(r, p.Limit, p.Offset+p.Limit, "next"))
+	}
+	if p.Offset > 0 {
+		prev := p.Offset - p.Limit
+		if prev < 0 {
+			prev = 0
+		}
+		links = append(links, formatLink(r, p.Limit, prev, "prev"))
+	}
+
+	if len(links) > 0 {
+		w.Header().Set("Link", strings.Join(links, ", "))
+	}
+}
+
+func formatLink(r *http.Request, limit, offset int, rel string) string {
+	u := *r.URL
+	q := u.Query()
+	q.Set("limit", strconv.Itoa(limit))
+	q.Set("offset", strconv.Itoa(offset))
+	u.RawQuery = q.Encode()
+	return fmt.Sprintf(`<%s>; rel=%q`, u.RequestURI(), rel)
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,175 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/sksmith/go-micro-example/api"
+	"github.com/sksmith/go-micro-example/core/inventory"
+)
+
+func paginationTestServer(t *testing.T) (*httptest.Server, *inventory.MockInventoryService) {
+	t.Helper()
+	mockSvc := inventory.NewMockInventoryService()
+	invApi := api.NewInventoryApi(mockSvc)
+	r := chi.NewRouter()
+	invApi.ConfigureRouter(r)
+	return httptest.NewServer(r), mockSvc
+}
+
+func TestPaginationRejectsInvalidInput(t *testing.T) {
+	ts, _ := paginationTestServer(t)
+	defer ts.Close()
+
+	tests := []struct {
+		name  string
+		query string
+		field string
+	}{
+		{"non-numeric limit", "limit=abc", "limit"},
+		{"zero limit", "limit=0", "limit"},
+		{"negative limit", "limit=-1", "limit"},
+		{"limit over max", "limit=" + strconv.Itoa(api.MaxPageLimit+1), "limit"},
+		{"non-numeric offset", "offset=xyz", "offset"},
+		{"negative offset", "offset=-5", "offset"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := http.Get(ts.URL + "/?" + tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer res.Body.Close()
+			if res.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status got=%d want=400", res.StatusCode)
+			}
+			if got := res.Header.Get("Content-Type"); !strings.HasPrefix(got, "application/problem+json") {
+				t.Errorf("content-type got=%q", got)
+			}
+			body, _ := io.ReadAll(res.Body)
+			var p api.Problem
+			if err := json.Unmarshal(body, &p); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(p.Errors) == 0 {
+				t.Fatalf("expected field-level errors[] extension, got %+v", p)
+			}
+			found := false
+			for _, fe := range p.Errors {
+				if fe.Field == tc.field {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected error on field %q, got %+v", tc.field, p.Errors)
+			}
+		})
+	}
+}
+
+func TestPaginationDefaultsAndClamp(t *testing.T) {
+	ts, mockSvc := paginationTestServer(t)
+	defer ts.Close()
+
+	var gotLimit, gotOffset int
+	mockSvc.GetAllProductInventoryFunc = func(ctx context.Context, limit, offset int) ([]inventory.ProductInventory, error) {
+		gotLimit, gotOffset = limit, offset
+		return nil, nil
+	}
+
+	// No query params — defaults apply.
+	res, err := http.Get(ts.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	if gotLimit != api.DefaultPageLimit {
+		t.Errorf("default limit got=%d want=%d", gotLimit, api.DefaultPageLimit)
+	}
+	if gotOffset != 0 {
+		t.Errorf("default offset got=%d want=0", gotOffset)
+	}
+
+	// Max-boundary limit accepted.
+	res, err = http.Get(ts.URL + "/?limit=" + strconv.Itoa(api.MaxPageLimit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	if gotLimit != api.MaxPageLimit {
+		t.Errorf("boundary limit got=%d want=%d", gotLimit, api.MaxPageLimit)
+	}
+}
+
+func TestPaginationLinkHeader(t *testing.T) {
+	ts, mockSvc := paginationTestServer(t)
+	defer ts.Close()
+
+	t.Run("full page emits next, no prev when offset=0", func(t *testing.T) {
+		mockSvc.GetAllProductInventoryFunc = func(ctx context.Context, limit, offset int) ([]inventory.ProductInventory, error) {
+			return make([]inventory.ProductInventory, limit), nil
+		}
+		res, err := http.Get(ts.URL + "/?limit=10")
+		if err != nil {
+			t.Fatal(err)
+		}
+		res.Body.Close()
+		link := res.Header.Get("Link")
+		if !strings.Contains(link, `rel="next"`) {
+			t.Errorf("expected next rel in Link header, got %q", link)
+		}
+		if strings.Contains(link, `rel="prev"`) {
+			t.Errorf("did not expect prev at offset=0, got %q", link)
+		}
+		if !strings.Contains(link, "offset=10") {
+			t.Errorf("next link should point at offset=10, got %q", link)
+		}
+	})
+
+	t.Run("middle page emits both next and prev", func(t *testing.T) {
+		mockSvc.GetAllProductInventoryFunc = func(ctx context.Context, limit, offset int) ([]inventory.ProductInventory, error) {
+			return make([]inventory.ProductInventory, limit), nil
+		}
+		res, err := http.Get(ts.URL + "/?limit=10&offset=20")
+		if err != nil {
+			t.Fatal(err)
+		}
+		res.Body.Close()
+		link := res.Header.Get("Link")
+		if !strings.Contains(link, `rel="next"`) || !strings.Contains(link, `rel="prev"`) {
+			t.Errorf("expected both next and prev, got %q", link)
+		}
+		if !strings.Contains(link, "offset=30") {
+			t.Errorf("next should be offset=30, got %q", link)
+		}
+		if !strings.Contains(link, "offset=10") {
+			t.Errorf("prev should be offset=10, got %q", link)
+		}
+	})
+
+	t.Run("partial page omits next", func(t *testing.T) {
+		mockSvc.GetAllProductInventoryFunc = func(ctx context.Context, limit, offset int) ([]inventory.ProductInventory, error) {
+			return make([]inventory.ProductInventory, limit-1), nil
+		}
+		res, err := http.Get(ts.URL + "/?limit=10&offset=10")
+		if err != nil {
+			t.Fatal(err)
+		}
+		res.Body.Close()
+		link := res.Header.Get("Link")
+		if strings.Contains(link, `rel="next"`) {
+			t.Errorf("did not expect next on partial page, got %q", link)
+		}
+		if !strings.Contains(link, `rel="prev"`) {
+			t.Errorf("expected prev on second page, got %q", link)
+		}
+	})
+}

--- a/api/reservationapi.go
+++ b/api/reservationapi.go
@@ -165,8 +165,7 @@ func (a *ReservationApi) ReservationCtx(next http.Handler) http.Handler {
 }
 
 func (a *ReservationApi) List(w http.ResponseWriter, r *http.Request) {
-	limit := r.Context().Value(CtxKeyLimit).(int)
-	offset := r.Context().Value(CtxKeyOffset).(int)
+	p := PaginationFrom(r.Context())
 
 	sku := r.URL.Query().Get("sku")
 
@@ -176,7 +175,7 @@ func (a *ReservationApi) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := a.service.GetReservations(r.Context(), inventory.GetReservationsOptions{Sku: sku, State: state}, limit, offset)
+	res, err := a.service.GetReservations(r.Context(), inventory.GetReservationsOptions{Sku: sku, State: state}, p.Limit, p.Offset)
 
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -187,6 +186,8 @@ func (a *ReservationApi) List(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	WriteLinkHeader(w, r, p, len(res))
 
 	resList := NewReservationListResponse(res)
 	render.Status(r, http.StatusOK)


### PR DESCRIPTION
## Summary

- New `api.Pagination` struct + `Paginate` middleware: invalid `limit`/`offset` returns `400 application/problem+json` with an `errors[]` extension naming the offending field. No more silent coercion.
- `limit` defaults to 50, must be a positive integer, capped at `MaxPageLimit = 200`. `offset` defaults to 0, must be non-negative.
- Validated values flow to handlers via `PaginationFrom(ctx)` instead of string-keyed `context.Value` lookups.
- List responses include an [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) `Link` header with `rel=\"next\"` (when the page is full) and `rel=\"prev\"` (when `offset > 0`).
- Both list endpoints (inventory, reservations) share the contract.

## Acceptance criteria (from [plan/DSN-011-pagination-contract.md](plan/DSN-011-pagination-contract.md))

- [x] Invalid `limit`/`offset` returns 400 with problem+json body — see [api/pagination_test.go](api/pagination_test.go) `TestPaginationRejectsInvalidInput`.
- [x] `limit` clamped to a documented max (200).
- [x] Responses include a `Link` header — see `TestPaginationLinkHeader`.
- [x] All list endpoints share the contract.

## Notes

- Picked Link-header pagination over `X-Total-Count` + envelope: services don't return a total count today; adding that would require repo changes well outside this ticket's scope. Cursor-based pagination remains a future option for inventory if offset becomes painful (a path the ticket explicitly leaves open).
- Removed the old string-keyed `CtxKeyLimit`/`CtxKeyOffset` constants and `DefaultPageLimit` from `middleware.go` — the typed `Pagination` struct + private `pageCtxKey{}` replaces them.
- `Validation` errors use the `ValidationProblem` + `FieldProblem` extension landed in DSN-010.

## Test plan

- [x] `make verify` green.
- [x] New tests cover invalid input (non-numeric / zero / negative / over-max), defaults + boundary, and three Link-header cases (full first page, middle page, partial last page).
- [x] README "Pagination" section documents the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)