### PR TITLE
DSN-021b: distributed rate limiter for /auth/token

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,39 @@ The TS step shells out to `npx openapi-typescript@7` — it needs Node
 locally and is intentionally out of CI's Go-only matrix. Reviewers spot
 TS drift by hand for now.
 
+### Rate limiting (auth-token)
+
+`/auth/token` is throttled by a distributed token-bucket rate
+limiter ([core/ratelimit](core/ratelimit/limiter.go), DSN-021b)
+backed by Redis. The bucket math runs inside a Lua script so the
+read-refill-subtract-write sequence is atomic against concurrent
+callers across replicas. Buckets are keyed per source IP
+(`X-Forwarded-For` is honoured when present, with `RemoteAddr` as
+the fallback).
+
+Behaviour:
+
+| Scenario | Response |
+| --- | --- |
+| Under rate | Request forwarded. `X-RateLimit-Remaining` set on the response. |
+| Over rate | 429 `application/problem+json`. `Retry-After` (seconds, minimum 1) and `X-RateLimit-Remaining` set. |
+| Redis unreachable | Limiter degrades open — request forwarded with a `ratelimit_errors_total` increment. The alternative (deny-on-error) turns a Redis blip into an outage. |
+| `GME_REDIS_URL` empty | Middleware not installed; `/auth/token` runs un-throttled. |
+
+Config (env vars):
+
+| env var | default | meaning |
+| --- | --- | --- |
+| `GME_RATELIMIT_AUTHRATEPERSECOND` | `1.0` | Token refill rate (per second). |
+| `GME_RATELIMIT_AUTHBURST` | `5` | Bucket capacity. |
+
+Prometheus metrics: `ratelimit_allowed_total{scope}`,
+`ratelimit_denied_total{scope}`, `ratelimit_errors_total`,
+`ratelimit_eval_duration_ms`.
+
+Other routes (`PUT /api/v1/...`, etc.) are not throttled today —
+SEC-007 will tune per-route policy.
+
 ### Redis cache (inventory read-path)
 
 `GET /api/v1/inventory/{sku}` reads through a Redis cache

--- a/api/api.go
+++ b/api/api.go
@@ -46,7 +46,10 @@ const (
 // idempotencyMw is the optional DSN-019 Idempotency-Key middleware.
 // nil leaves the mutating routes unwrapped; non-nil applies it to
 // productionEvent and the reservation Create route.
-func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc ReservationService, userService UserService, signer *auth.Signer, readinessDeps map[string]Pinger, catalogClient catalog.Client, idempotencyMw func(http.Handler) http.Handler) chi.Router {
+//
+// authRateLimitMw is the optional DSN-021b rate-limit middleware
+// applied to /auth/token. nil leaves the route un-throttled.
+func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc ReservationService, userService UserService, signer *auth.Signer, readinessDeps map[string]Pinger, catalogClient catalog.Client, idempotencyMw func(http.Handler) http.Handler, authRateLimitMw func(http.Handler) http.Handler) chi.Router {
 	log.Info().Msg("configuring router...")
 	r := chi.NewRouter()
 
@@ -83,7 +86,9 @@ func ConfigureRouter(cfg *config.Config, invSvc InventoryService, resSvc Reserva
 	}
 
 	if signer != nil {
-		r.Route(AuthPath, NewAuthApi(userService, signer).ConfigureRouter)
+		authApi := NewAuthApi(userService, signer)
+		authApi.SetRateLimit(authRateLimitMw)
+		r.Route(AuthPath, authApi.ConfigureRouter)
 	}
 
 	r.With(Authenticate(signer)).Route(ApiPath, func(r chi.Router) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -34,7 +34,7 @@ func newTestRouterWithSigner() (chi.Router, *user.MockUserService, *auth.Signer)
 	if err != nil {
 		panic(err)
 	}
-	return api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc, signer, nil, nil, nil), usrSvc, signer
+	return api.ConfigureRouter(cfg, invSvc, resSvc, usrSvc, signer, nil, nil, nil, nil), usrSvc, signer
 }
 
 func TestCorsConfig(t *testing.T) {

--- a/api/authapi.go
+++ b/api/authapi.go
@@ -16,6 +16,8 @@ import (
 // credentials and receive a short-lived bearer JWT — the only accepted
 // credential on protected routes after SEC-002c.
 type AuthApi struct {
+	rateLimit func(http.Handler) http.Handler
+
 	users  UserService
 	signer *auth.Signer
 }
@@ -35,8 +37,19 @@ func NewAuthApi(users UserService, signer *auth.Signer) *AuthApi {
 	return &AuthApi{users: users, signer: signer}
 }
 
+// SetRateLimit installs the optional DSN-021b rate-limit middleware
+// applied to /auth/token. nil disables throttling on that route.
+func (a *AuthApi) SetRateLimit(mw func(http.Handler) http.Handler) {
+	a.rateLimit = mw
+}
+
 func (a *AuthApi) ConfigureRouter(r chi.Router) {
-	r.Post("/token", a.Token)
+	token := http.HandlerFunc(a.Token)
+	if a.rateLimit != nil {
+		r.Method(http.MethodPost, "/token", a.rateLimit(token))
+	} else {
+		r.Post("/token", token.ServeHTTP)
+	}
 }
 
 // Token exchanges HTTP Basic credentials for a short-lived bearer JWT.

--- a/api/client/v1/client.gen.go
+++ b/api/client/v1/client.gen.go
@@ -105,6 +105,7 @@ type ApiEnvResponse struct {
 	Port        *ConfigStringConfig      `json:"port,omitempty"`
 	Profile     *ConfigStringConfig      `json:"profile,omitempty"`
 	Rabbitmq    *ConfigQueueConfig       `json:"rabbitmq,omitempty"`
+	RateLimit   *ConfigRateLimitConfig   `json:"rateLimit,omitempty"`
 	Redis       *ConfigRedisConfig       `json:"redis,omitempty"`
 	Revision    *ConfigStringConfig      `json:"revision,omitempty"`
 	Sha1Version *ConfigStringConfig      `json:"sha1Version,omitempty"`
@@ -225,6 +226,13 @@ type ConfigDocsConfig struct {
 	Enabled     *ConfigBoolConfig `json:"enabled,omitempty"`
 }
 
+// ConfigFloatConfig defines model for config.FloatConfig.
+type ConfigFloatConfig struct {
+	Default     *float32 `json:"default,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Value       *float32 `json:"value,omitempty"`
+}
+
 // ConfigIdempotencyConfig defines model for config.IdempotencyConfig.
 type ConfigIdempotencyConfig struct {
 	Description *string          `json:"description,omitempty"`
@@ -284,6 +292,13 @@ type ConfigQueueConfig struct {
 	Product     *ConfigProductQueueConfig     `json:"product,omitempty"`
 	Reservation *ConfigReservationQueueConfig `json:"reservation,omitempty"`
 	User        *ConfigStringConfig           `json:"user,omitempty"`
+}
+
+// ConfigRateLimitConfig defines model for config.RateLimitConfig.
+type ConfigRateLimitConfig struct {
+	AuthBurst         *ConfigIntConfig   `json:"authBurst,omitempty"`
+	AuthRatePerSecond *ConfigFloatConfig `json:"authRatePerSecond,omitempty"`
+	Description       *string            `json:"description,omitempty"`
 }
 
 // ConfigRedisConfig defines model for config.RedisConfig.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -99,6 +99,9 @@
                     "rabbitmq": {
                         "$ref": "#/components/schemas/config.QueueConfig"
                     },
+                    "rateLimit": {
+                        "$ref": "#/components/schemas/config.RateLimitConfig"
+                    },
                     "redis": {
                         "$ref": "#/components/schemas/config.RedisConfig"
                     },
@@ -355,6 +358,20 @@
                 },
                 "type": "object"
             },
+            "config.FloatConfig": {
+                "properties": {
+                    "default": {
+                        "type": "number"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
             "config.IdempotencyConfig": {
                 "properties": {
                     "description": {
@@ -478,6 +495,20 @@
                     },
                     "user": {
                         "$ref": "#/components/schemas/config.StringConfig"
+                    }
+                },
+                "type": "object"
+            },
+            "config.RateLimitConfig": {
+                "properties": {
+                    "authBurst": {
+                        "$ref": "#/components/schemas/config.IntConfig"
+                    },
+                    "authRatePerSecond": {
+                        "$ref": "#/components/schemas/config.FloatConfig"
+                    },
+                    "description": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -69,6 +69,8 @@ components:
           $ref: '#/components/schemas/config.StringConfig'
         rabbitmq:
           $ref: '#/components/schemas/config.QueueConfig'
+        rateLimit:
+          $ref: '#/components/schemas/config.RateLimitConfig'
         redis:
           $ref: '#/components/schemas/config.RedisConfig'
         revision:
@@ -235,6 +237,15 @@ components:
         enabled:
           $ref: '#/components/schemas/config.BoolConfig'
       type: object
+    config.FloatConfig:
+      properties:
+        default:
+          type: number
+        description:
+          type: string
+        value:
+          type: number
+      type: object
     config.IdempotencyConfig:
       properties:
         description:
@@ -316,6 +327,15 @@ components:
           $ref: '#/components/schemas/config.ReservationQueueConfig'
         user:
           $ref: '#/components/schemas/config.StringConfig'
+      type: object
+    config.RateLimitConfig:
+      properties:
+        authBurst:
+          $ref: '#/components/schemas/config.IntConfig'
+        authRatePerSecond:
+          $ref: '#/components/schemas/config.FloatConfig'
+        description:
+          type: string
       type: object
     config.RedisConfig:
       properties:

--- a/cmd/demo/ratelimit_step.go
+++ b/cmd/demo/ratelimit_step.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+// runRateLimitBurst exercises DSN-021b end-to-end. The step sends a
+// burst of /auth/token requests in rapid succession and asserts at
+// least one 429 came back. The default config is 1 token/sec, burst
+// 5; sending 20 requests in a tight loop blows past the bucket
+// regardless of how much it has refilled since the previous demo
+// step. Earlier steps each spent one token via fetchToken, and the
+// natural gaps between steps refill the bucket — so the bucket
+// state at this point is at most a few tokens, definitely not
+// enough to absorb 20 in a burst.
+//
+// This step runs LAST in the demo so a half-empty bucket can't
+// starve subsequent steps' fetchToken calls.
+func runRateLimitBurst(ctx context.Context, cfg Config) (string, error) {
+	const attempts = 20
+
+	var denied int32
+	for i := 0; i < attempts; i++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.BaseURL+"/auth/token", nil)
+		if err != nil {
+			return "", fmt.Errorf("build req: %w", err)
+		}
+		req.SetBasicAuth(cfg.AdminUser, cfg.AdminPass)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("request %d: %w", i, err)
+		}
+		_ = res.Body.Close()
+		if res.StatusCode == http.StatusTooManyRequests {
+			atomic.AddInt32(&denied, 1)
+		}
+	}
+
+	got := atomic.LoadInt32(&denied)
+	if got == 0 {
+		return "", fmt.Errorf("sent %d /auth/token requests in a burst; zero 429s came back (rate limiter is not engaged)", attempts)
+	}
+	// No specific upper bound — just confirming the limiter fired
+	// at least once. With burst=5 and 20 attempts, we'd expect
+	// ~15 denials, but the exact number depends on inter-request
+	// latency and any refill that happened mid-loop.
+	return "", nil
+}

--- a/cmd/demo/steps.go
+++ b/cmd/demo/steps.go
@@ -55,6 +55,11 @@ var Steps = []Step{
 		Name:       "Redis cache: second read is a hit",
 		Run:        runCacheRead,
 	},
+	{
+		Capability: "DSN-021b",
+		Name:       "Auth-token burst trips rate limiter (429)",
+		Run:        runRateLimitBurst,
+	},
 }
 
 // runRESTRoundTrip exchanges admin Basic credentials for a JWT,

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -57,7 +57,7 @@ func TestMain(m *testing.M) {
 
 	userService := user.NewService(ur)
 
-	r := api.ConfigureRouter(cfg, invService, invService, userService, nil, map[string]api.Pinger{"db": dbPool}, nil, nil)
+	r := api.ConfigureRouter(cfg, invService, invService, userService, nil, map[string]api.Pinger{"db": dbPool}, nil, nil, nil)
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sksmith/go-micro-example/core/catalog"
 	"github.com/sksmith/go-micro-example/core/inventory"
 	"github.com/sksmith/go-micro-example/core/observability"
+	"github.com/sksmith/go-micro-example/core/ratelimit"
 	"github.com/sksmith/go-micro-example/core/secrets"
 	"github.com/sksmith/go-micro-example/core/user"
 	"github.com/sksmith/go-micro-example/db"
@@ -135,7 +136,8 @@ func main() {
 	}
 	catalogClient := buildCatalogClient(cfg)
 	idempotencyMw := buildIdempotencyMiddleware(cfg, redisClient)
-	r := api.ConfigureRouter(cfg, invService, invService, userService, signer, readinessDeps, catalogClient, idempotencyMw)
+	authRateLimitMw := buildAuthRateLimitMiddleware(cfg, redisClient)
+	r := api.ConfigureRouter(cfg, invService, invService, userService, signer, readinessDeps, catalogClient, idempotencyMw, authRateLimitMw)
 
 	_ = queue.NewProductQueue(ctx, cfg, invService)
 
@@ -215,6 +217,27 @@ func buildRedisClient(cfg *config.Config) *redis.Client {
 	client := redis.NewClient(opts)
 	log.Info().Str("addr", opts.Addr).Int("db", opts.DB).Msg("redis client ready")
 	return client
+}
+
+// buildAuthRateLimitMiddleware constructs the DSN-021b rate limiter
+// for /auth/token, bucketed per source IP. Returning a pass-through
+// when Redis isn't wired keeps every-other-route's behaviour
+// unchanged; the rate limiter needs a shared store to be useful and
+// degrades transparently when one isn't there.
+func buildAuthRateLimitMiddleware(cfg *config.Config, redisClient *redis.Client) func(http.Handler) http.Handler {
+	if redisClient == nil {
+		log.Info().Msg("auth-token rate limiter disabled (no redis client)")
+		return func(next http.Handler) http.Handler { return next }
+	}
+	limiter := ratelimit.New(redisClient, ratelimit.Config{
+		Rate:  cfg.RateLimit.AuthRatePerSecond.Value,
+		Burst: int(cfg.RateLimit.AuthBurst.Value),
+	})
+	log.Info().
+		Float64("rate", cfg.RateLimit.AuthRatePerSecond.Value).
+		Int64("burst", cfg.RateLimit.AuthBurst.Value).
+		Msg("auth-token rate limiter ready")
+	return ratelimit.Middleware(limiter, ratelimit.IPKey)
 }
 
 // buildIdempotencyMiddleware constructs the DSN-019 Idempotency-Key

--- a/config/config.go
+++ b/config/config.go
@@ -74,17 +74,28 @@ type Config struct {
 	Catalog     CatalogConfig     `json:"catalog"    yaml:"catalog"`
 	Idempotency IdempotencyConfig `json:"idempotency" yaml:"idempotency"`
 	Redis       RedisConfig       `json:"redis"       yaml:"redis"`
+	RateLimit   RateLimitConfig   `json:"rateLimit"   yaml:"rateLimit"`
 	Docs        DocsConfig        `json:"docs"        yaml:"docs"`
 }
 
 // RedisConfig holds the DSN-020 Redis connection knobs. An empty URL
 // disables the cache; the inventory API then serves every read from
-// the database. The same client (once DSN-021 lands) will back the
-// rate limiter, idempotency store, and user cache.
+// the database. The same client backs the DSN-021 family (rate
+// limiter, idempotency store, user cache).
 type RedisConfig struct {
 	URL             StringConfig `json:"url"            yaml:"url"            sensitive:"true"`
 	CacheTTLMinutes IntConfig    `json:"cacheTtlMinutes" yaml:"cacheTtlMinutes"`
 	Description     string       `json:"description"    yaml:"description"`
+}
+
+// RateLimitConfig configures the DSN-021b auth-token rate limiter.
+// Empty or zero values fall through to package defaults. When
+// redis.url is empty the limiter is disabled regardless of these
+// values — the middleware needs Redis to function.
+type RateLimitConfig struct {
+	AuthRatePerSecond FloatConfig `json:"authRatePerSecond" yaml:"authRatePerSecond"`
+	AuthBurst         IntConfig   `json:"authBurst"         yaml:"authBurst"`
+	Description       string      `json:"description"       yaml:"description"`
 }
 
 // IdempotencyConfig holds the DSN-019 REST idempotency knobs. The
@@ -280,6 +291,8 @@ func bindSensitiveEnv() {
 		"idempotency.ttlMinutes",
 		"redis.url",
 		"redis.cacheTtlMinutes",
+		"rateLimit.authRatePerSecond",
+		"rateLimit.authBurst",
 	} {
 		// Errors here would mean a programming error in the key list —
 		// viper.BindEnv only fails on empty input.
@@ -576,6 +589,10 @@ func setupDefaults(config *Config) {
 	config.Redis.Description = "DSN-020: Redis URL for the inventory read-path cache. Empty disables the client entirely."
 	config.Redis.URL = StringConfig{Value: "", Default: "", Description: "Redis connection URL (redis://host:port/db). Empty disables the cache."}
 	config.Redis.CacheTTLMinutes = IntConfig{Value: 5, Default: 5, Description: "TTL for cached ProductInventory entries, in minutes. Short by default so missed invalidations self-heal."}
+
+	config.RateLimit.Description = "DSN-021b: per-IP rate limit for /auth/token (brute-force throttle). Requires redis.url; disabled when Redis isn't configured."
+	config.RateLimit.AuthRatePerSecond = FloatConfig{Value: 1.0, Default: 1.0, Description: "Token refill rate (tokens/sec) for the /auth/token bucket."}
+	config.RateLimit.AuthBurst = IntConfig{Value: 5, Default: 5, Description: "Bucket size for the /auth/token rate limiter (burst capacity)."}
 
 	config.Config.Description = "Settings for where and how the application should get its configurations."
 	config.Config.Print = BoolConfig{Value: false, Default: false, Description: "Print configurations on startup."}

--- a/core/ratelimit/limiter.go
+++ b/core/ratelimit/limiter.go
@@ -1,0 +1,188 @@
+// Package ratelimit is the distributed-token-bucket rate limiter
+// introduced by DSN-021b. The bucket lives in Redis so multiple
+// replicas share one budget per (limit-prefix, identity) instead of
+// each replica enforcing its own ceiling.
+//
+// The bucket math runs inside a Lua script (script.lua) so the
+// "read tokens, refill, subtract, write back" sequence is atomic
+// from Redis's perspective — two simultaneous callers can't both
+// observe the same token count and both subtract. Lua is the
+// canonical pattern for this on Redis and avoids reaching for a
+// third-party rate-limit library to wrap ~30 lines of clarity.
+//
+// The package separates concerns:
+//
+//   - Limiter is the transport-agnostic core. Allow(ctx, key, ...)
+//     returns a Decision; callers (HTTP middleware, eventual gRPC
+//     interceptor, queue consumer back-pressure) translate that into
+//     the right response shape.
+//   - Middleware (middleware.go) is the HTTP wrapper used by
+//     cmd/main on the brute-force-sensitive routes.
+//
+// Redis outages degrade open. The alternative — denying every
+// request when Redis flaps — turns a cache outage into a service
+// outage, and brute-force attempts are a worse problem than a
+// momentary lapse in throttling.
+package ratelimit
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog/log"
+)
+
+//go:embed script.lua
+var luaSource string
+
+var luaScript = redis.NewScript(luaSource)
+
+// RedisClient is the slice of *redis.Client Limiter actually needs.
+// Narrowing keeps tests fakeable without reimplementing the whole
+// Cmdable surface. *redis.Client and *redis.ClusterClient satisfy
+// this interface directly.
+type RedisClient interface {
+	redis.Scripter
+}
+
+// Config is the per-Limiter knobs. Rate is tokens-per-second; Burst
+// is the bucket ceiling. KeyTTL is the Redis expiry applied to
+// abandoned bucket rows — comfortably longer than (Burst / Rate)
+// seconds so a paused user's bucket doesn't get swept mid-window.
+type Config struct {
+	Rate   float64
+	Burst  int
+	KeyTTL time.Duration
+}
+
+// Decision is the typed result of an Allow call. Allowed reports
+// whether the request gets through; Remaining is the tokens left in
+// the bucket after the call (useful for X-RateLimit-Remaining
+// headers); RetryAfter is the time the caller should wait before
+// trying again (zero on allow, populated on deny).
+type Decision struct {
+	Allowed    bool
+	Remaining  int64
+	RetryAfter time.Duration
+}
+
+// Limiter applies the token-bucket logic against Redis.
+type Limiter struct {
+	client RedisClient
+	cfg    Config
+}
+
+func New(client RedisClient, cfg Config) *Limiter {
+	if cfg.Rate <= 0 {
+		cfg.Rate = 1
+	}
+	if cfg.Burst <= 0 {
+		cfg.Burst = 1
+	}
+	if cfg.KeyTTL <= 0 {
+		// Default: ten full-bucket windows. Long enough that a
+		// paused user doesn't lose their accumulated tokens on a
+		// natural pause; short enough that abandoned bucket keys
+		// don't accumulate indefinitely.
+		cfg.KeyTTL = time.Duration(float64(cfg.Burst)/cfg.Rate*10) * time.Second
+		if cfg.KeyTTL < time.Minute {
+			cfg.KeyTTL = time.Minute
+		}
+	}
+	ensureMetrics()
+	return &Limiter{client: client, cfg: cfg}
+}
+
+var (
+	metricsOnce    sync.Once
+	allowedTotal   *prometheus.CounterVec
+	deniedTotal    *prometheus.CounterVec
+	errorsTotal    prometheus.Counter
+	limiterLatency prometheus.Histogram
+)
+
+func ensureMetrics() {
+	metricsOnce.Do(func() {
+		allowedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ratelimit_allowed_total",
+			Help: "Rate-limit decisions that allowed the request.",
+		}, []string{"scope"})
+		deniedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ratelimit_denied_total",
+			Help: "Rate-limit decisions that denied the request (HTTP 429).",
+		}, []string{"scope"})
+		errorsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "ratelimit_errors_total",
+			Help: "Lua/redis errors that forced the limiter to degrade open.",
+		})
+		limiterLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "ratelimit_eval_duration_ms",
+			Help:    "Time to evaluate one rate-limit check (ms).",
+			Buckets: []float64{0.5, 1, 2, 5, 10, 25, 50, 100},
+		})
+		prometheus.MustRegister(allowedTotal, deniedTotal, errorsTotal, limiterLatency)
+	})
+}
+
+// Allow runs the Lua bucket against key. A non-nil error means the
+// limiter couldn't reach Redis or the script returned an unexpected
+// shape — the caller should treat that as "fail open" (the Middleware
+// in this package does). Scope is a label for metrics ("ip" / "user").
+func (l *Limiter) Allow(ctx context.Context, key, scope string) (Decision, error) {
+	start := time.Now()
+	defer func() { limiterLatency.Observe(float64(time.Since(start).Microseconds()) / 1000) }()
+
+	nowMs := time.Now().UnixMilli()
+	ttlSeconds := int64(l.cfg.KeyTTL.Seconds())
+	if ttlSeconds < 1 {
+		ttlSeconds = 60
+	}
+
+	res, err := luaScript.Run(ctx, l.client, []string{key},
+		l.cfg.Rate, l.cfg.Burst, 1, nowMs, ttlSeconds,
+	).Result()
+	if err != nil {
+		errorsTotal.Inc()
+		return Decision{Allowed: true}, fmt.Errorf("ratelimit eval: %w", err)
+	}
+
+	parts, ok := res.([]any)
+	if !ok || len(parts) < 3 {
+		errorsTotal.Inc()
+		return Decision{Allowed: true}, errors.New("ratelimit: unexpected script return shape")
+	}
+
+	allowed := toInt64(parts[0]) == 1
+	remaining := toInt64(parts[1])
+	retryAfterMs := toInt64(parts[2])
+
+	if allowed {
+		allowedTotal.WithLabelValues(scope).Inc()
+	} else {
+		deniedTotal.WithLabelValues(scope).Inc()
+	}
+	return Decision{
+		Allowed:    allowed,
+		Remaining:  remaining,
+		RetryAfter: time.Duration(retryAfterMs) * time.Millisecond,
+	}, nil
+}
+
+func toInt64(v any) int64 {
+	switch t := v.(type) {
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	case float64:
+		return int64(t)
+	}
+	log.Warn().Interface("v", v).Msg("ratelimit: unexpected Lua return type; treating as 0")
+	return 0
+}

--- a/core/ratelimit/middleware.go
+++ b/core/ratelimit/middleware.go
@@ -1,0 +1,103 @@
+package ratelimit
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Allower is the slice of Limiter's surface the middleware actually
+// uses. Exposed so tests can drive the middleware with a deterministic
+// fake without reaching for a Redis (or even a Lua interpreter).
+// *Limiter satisfies this interface in production code.
+type Allower interface {
+	Allow(ctx context.Context, key, scope string) (Decision, error)
+}
+
+// KeyFunc derives the bucket key + scope label from a request.
+// Returning ("", _) skips the limiter entirely (useful for routes
+// where we can't extract an identity yet — let the request through).
+type KeyFunc func(*http.Request) (key, scope string)
+
+// IPKey buckets by the client IP. X-Forwarded-For is honoured when
+// present (first hop wins) because the demo runs behind compose's
+// proxying; production deployments behind a real load balancer should
+// configure the LB to write a trusted header before this middleware
+// runs, OR replace this with a stricter source.
+func IPKey(r *http.Request) (string, string) {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i > 0 {
+			return "rl:ip:" + strings.TrimSpace(xff[:i]), "ip"
+		}
+		return "rl:ip:" + strings.TrimSpace(xff), "ip"
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	return "rl:ip:" + host, "ip"
+}
+
+// Middleware returns an http middleware that consumes one token per
+// request from the bucket keyed by keyFn(r). Denials are returned as
+// 429 application/problem+json with Retry-After populated. A Redis
+// error degrades open: the request is logged and forwarded to the
+// next handler. The alternative — failing closed — turns a Redis
+// outage into a service outage and is worse than missing throttling
+// for the duration of the blip.
+func Middleware(limiter Allower, keyFn KeyFunc) func(http.Handler) http.Handler {
+	if limiter == nil {
+		// nil limiter = pass-through. cmd/main uses this when the
+		// shared Redis client wasn't wired (redis.url empty); the
+		// router stays unchanged.
+		return func(next http.Handler) http.Handler { return next }
+	}
+	if keyFn == nil {
+		keyFn = IPKey
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key, scope := keyFn(r)
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			dec, err := limiter.Allow(r.Context(), key, scope)
+			if err != nil {
+				log.Ctx(r.Context()).Warn().Err(err).Str("key", key).Msg("rate limiter degraded open after error")
+				next.ServeHTTP(w, r)
+				return
+			}
+			w.Header().Set("X-RateLimit-Remaining", strconv.FormatInt(dec.Remaining, 10))
+			if !dec.Allowed {
+				retrySec := int(dec.RetryAfter / time.Second)
+				if retrySec < 1 {
+					retrySec = 1
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retrySec))
+				writeProblem(w, r, http.StatusTooManyRequests, "rate limit exceeded; retry after "+strconv.Itoa(retrySec)+"s")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeProblem(w http.ResponseWriter, r *http.Request, status int, detail string) {
+	body, _ := json.Marshal(map[string]any{
+		"type":     "about:blank",
+		"title":    http.StatusText(status),
+		"status":   status,
+		"detail":   detail,
+		"instance": r.URL.Path,
+	})
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}

--- a/core/ratelimit/middleware_test.go
+++ b/core/ratelimit/middleware_test.go
@@ -1,0 +1,181 @@
+package ratelimit_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sksmith/go-micro-example/core/ratelimit"
+)
+
+// stubLimiter is an Allower that returns canned Decisions. The
+// per-call counter lets tests assert how often the middleware
+// consulted the limiter; the err field exercises the degrade-open
+// branch.
+type stubLimiter struct {
+	calls    int32
+	decision ratelimit.Decision
+	err      error
+}
+
+func (s *stubLimiter) Allow(_ context.Context, _, _ string) (ratelimit.Decision, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return s.decision, s.err
+}
+
+func runRequest(t *testing.T, h http.Handler, remoteAddr string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/auth/token", strings.NewReader(""))
+	req.RemoteAddr = remoteAddr
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func okHandler(called *int32) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(called, 1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func TestMiddlewareAllowsRequestUnderLimit(t *testing.T) {
+	limiter := &stubLimiter{decision: ratelimit.Decision{Allowed: true, Remaining: 9}}
+	var handlerCalls int32
+	h := ratelimit.Middleware(limiter, ratelimit.IPKey)(okHandler(&handlerCalls))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status=%d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("X-RateLimit-Remaining"); got != "9" {
+		t.Errorf("X-RateLimit-Remaining=%q, want 9", got)
+	}
+	if atomic.LoadInt32(&handlerCalls) != 1 {
+		t.Errorf("handler ran %d times; want 1", handlerCalls)
+	}
+}
+
+func TestMiddlewareDeniesOverLimitWith429(t *testing.T) {
+	limiter := &stubLimiter{decision: ratelimit.Decision{
+		Allowed:    false,
+		Remaining:  0,
+		RetryAfter: 7 * time.Second,
+	}}
+	var handlerCalls int32
+	h := ratelimit.Middleware(limiter, ratelimit.IPKey)(okHandler(&handlerCalls))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "7" {
+		t.Errorf("Retry-After=%q, want 7", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("Content-Type=%q, want application/problem+json", got)
+	}
+	if atomic.LoadInt32(&handlerCalls) != 0 {
+		t.Errorf("handler ran %d times on denial; want 0", handlerCalls)
+	}
+}
+
+func TestMiddlewareDegradesOpenOnLimiterError(t *testing.T) {
+	limiter := &stubLimiter{err: errors.New("redis down")}
+	var handlerCalls int32
+	h := ratelimit.Middleware(limiter, ratelimit.IPKey)(okHandler(&handlerCalls))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status=%d, want 204 (degrade open)", rec.Code)
+	}
+	if atomic.LoadInt32(&handlerCalls) != 1 {
+		t.Errorf("handler ran %d times; want 1 (degrade open should forward)", handlerCalls)
+	}
+}
+
+func TestMiddlewareNilLimiterIsPassthrough(t *testing.T) {
+	var handlerCalls int32
+	h := ratelimit.Middleware(nil, ratelimit.IPKey)(okHandler(&handlerCalls))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status=%d, want 204", rec.Code)
+	}
+	if atomic.LoadInt32(&handlerCalls) != 1 {
+		t.Errorf("handler ran %d times; want 1", handlerCalls)
+	}
+}
+
+func TestMiddlewareEmptyKeySkipsLimiter(t *testing.T) {
+	limiter := &stubLimiter{decision: ratelimit.Decision{Allowed: false}}
+	var handlerCalls int32
+	noKey := func(_ *http.Request) (string, string) { return "", "ip" }
+	h := ratelimit.Middleware(limiter, noKey)(okHandler(&handlerCalls))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status=%d, want 204 (empty key bypasses limiter)", rec.Code)
+	}
+	if atomic.LoadInt32(&limiter.calls) != 0 {
+		t.Errorf("limiter consulted %d times; want 0", limiter.calls)
+	}
+}
+
+func TestIPKeyHonoursXForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.1")
+
+	key, scope := ratelimit.IPKey(req)
+	if key != "rl:ip:203.0.113.5" {
+		t.Errorf("key=%q, want rl:ip:203.0.113.5", key)
+	}
+	if scope != "ip" {
+		t.Errorf("scope=%q, want ip", scope)
+	}
+}
+
+func TestIPKeyFallsBackToRemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	key, _ := ratelimit.IPKey(req)
+	if key != "rl:ip:10.0.0.1" {
+		t.Errorf("key=%q, want rl:ip:10.0.0.1", key)
+	}
+}
+
+// TestMiddlewareRetryAfterClampsToOneSecondMinimum confirms a deny
+// with a sub-second RetryAfter still surfaces a non-zero Retry-After
+// header — otherwise clients see "Retry-After: 0" and bash on the
+// endpoint immediately.
+func TestMiddlewareRetryAfterClampsToOneSecondMinimum(t *testing.T) {
+	limiter := &stubLimiter{decision: ratelimit.Decision{
+		Allowed:    false,
+		RetryAfter: 100 * time.Millisecond,
+	}}
+	h := ratelimit.Middleware(limiter, ratelimit.IPKey)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := runRequest(t, h, "10.0.0.1:1234")
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "1" {
+		t.Errorf("Retry-After=%q, want 1 (clamped from 100ms)", got)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if !strings.Contains(string(body), `"status":429`) {
+		t.Errorf("problem body missing status:429: %s", string(body))
+	}
+}

--- a/core/ratelimit/script.lua
+++ b/core/ratelimit/script.lua
@@ -1,0 +1,64 @@
+-- Token-bucket rate limiter (DSN-021b).
+--
+-- The bucket is two Redis fields under one key:
+--   tokens  : current token count (float, may be fractional after refill)
+--   last_ms : last refill timestamp in ms-since-epoch
+--
+-- Refill formula: tokens = min(burst, tokens + elapsed_seconds * rate).
+-- A request is allowed iff tokens >= cost; on allow we subtract cost.
+-- Everything happens inside this one EVAL so concurrent callers can't
+-- both see N tokens and both subtract — the script runs atomically on
+-- the Redis side.
+--
+-- KEYS[1] : the bucket key, e.g. "rl:ip:1.2.3.4"
+-- ARGV[1] : refill rate (tokens per second), as a number
+-- ARGV[2] : burst (max tokens the bucket can hold)
+-- ARGV[3] : cost of this request (usually 1)
+-- ARGV[4] : now (ms-since-epoch) — pulled from the caller so tests are
+--           deterministic and so we don't have to enable replica-script
+--           effects on TIME
+-- ARGV[5] : ttl_seconds — Redis key expiry so abandoned buckets are
+--           swept (longer than the time it takes a full bucket to refill)
+--
+-- Returns {allowed, remaining_tokens_rounded, retry_after_ms}:
+--   allowed         : 1 if the request is allowed, 0 if denied
+--   remaining_tokens: floor of the tokens left after the call
+--   retry_after_ms  : ms until enough tokens accumulate for the next
+--                     request (0 if allowed)
+
+local key  = KEYS[1]
+local rate = tonumber(ARGV[1])
+local burst = tonumber(ARGV[2])
+local cost = tonumber(ARGV[3])
+local now_ms = tonumber(ARGV[4])
+local ttl = tonumber(ARGV[5])
+
+local data = redis.call('HMGET', key, 'tokens', 'last_ms')
+local tokens = tonumber(data[1])
+local last_ms = tonumber(data[2])
+
+if tokens == nil then
+  tokens = burst
+  last_ms = now_ms
+end
+
+local elapsed_ms = now_ms - last_ms
+if elapsed_ms < 0 then elapsed_ms = 0 end
+local refilled = tokens + (elapsed_ms / 1000) * rate
+if refilled > burst then refilled = burst end
+
+local allowed = 0
+local retry_after_ms = 0
+if refilled >= cost then
+  refilled = refilled - cost
+  allowed = 1
+else
+  -- Time (ms) until we'd accumulate enough tokens for one more request.
+  local needed = cost - refilled
+  retry_after_ms = math.ceil((needed / rate) * 1000)
+end
+
+redis.call('HMSET', key, 'tokens', refilled, 'last_ms', now_ms)
+redis.call('EXPIRE', key, ttl)
+
+return {allowed, math.floor(refilled), retry_after_ms}

--- a/web/src/api/schema.ts
+++ b/web/src/api/schema.ts
@@ -705,6 +705,7 @@ export interface components {
             port?: components["schemas"]["config.StringConfig"];
             profile?: components["schemas"]["config.StringConfig"];
             rabbitmq?: components["schemas"]["config.QueueConfig"];
+            rateLimit?: components["schemas"]["config.RateLimitConfig"];
             redis?: components["schemas"]["config.RedisConfig"];
             revision?: components["schemas"]["config.StringConfig"];
             sha1Version?: components["schemas"]["config.StringConfig"];
@@ -793,6 +794,11 @@ export interface components {
             description?: string;
             enabled?: components["schemas"]["config.BoolConfig"];
         };
+        "config.FloatConfig": {
+            default?: number;
+            description?: string;
+            value?: number;
+        };
         "config.IdempotencyConfig": {
             description?: string;
             ttlMinutes?: components["schemas"]["config.IntConfig"];
@@ -837,6 +843,11 @@ export interface components {
             product?: components["schemas"]["config.ProductQueueConfig"];
             reservation?: components["schemas"]["config.ReservationQueueConfig"];
             user?: components["schemas"]["config.StringConfig"];
+        };
+        "config.RateLimitConfig": {
+            authBurst?: components["schemas"]["config.IntConfig"];
+            authRatePerSecond?: components["schemas"]["config.FloatConfig"];
+            description?: string;
         };
         "config.RedisConfig": {
             cacheTtlMinutes?: components["schemas"]["config.IntConfig"];


### PR DESCRIPTION
## Summary

Adds a Redis-backed token-bucket rate limiter
([core/ratelimit](core/ratelimit/limiter.go)) and wires it into
`/auth/token` — the brute-force-sensitive route. The bucket math
runs inside a Lua script
([core/ratelimit/script.lua](core/ratelimit/script.lua)) so the
read-refill-subtract-write sequence is atomic against concurrent
callers, which means multiple replicas share one budget per source
IP instead of each replica enforcing its own.

Behaviour:

| Scenario | Response |
| --- | --- |
| Under rate | Request forwarded. `X-RateLimit-Remaining` set. |
| Over rate | 429 `application/problem+json`. `Retry-After` (≥1s) + `X-RateLimit-Remaining` set. |
| Redis unreachable | Limiter degrades open; `ratelimit_errors_total` increments. |
| `GME_REDIS_URL` empty | Middleware is pass-through; `/auth/token` runs un-throttled. |

The middleware sits behind an `Allower` interface so unit tests can
drive it with a deterministic fake — no Lua interpreter or Redis
needed for the middleware contract tests. The Lua correctness is
covered end-to-end by the demo step.

## Acceptance criteria

- [x] `core/ratelimit` package exposes `Limiter.Allow` + an HTTP
  middleware that returns 429 `application/problem+json` on denial.
- [x] Atomic via Lua (`script.lua`), embedded with `go:embed`,
  reloaded automatically on `NOSCRIPT` by `redis.NewScript.Run`.
- [x] Per-IP keying. `X-Forwarded-For` honoured (first hop wins),
  with `RemoteAddr` as the fallback.
- [x] Configurable rate + burst via env vars; defaults 1/sec, burst 5.
- [x] Wired onto `/auth/token` at minimum. Other routes remain open
  for now; SEC-007 will tune per-route policy.
- [x] Redis outage degrades open. `ratelimit_errors_total` surfaces it.
- [x] DSN-015: demo step sends a 20-request burst and asserts at
  least one 429.
- [x] Tests: allow, deny + Retry-After, degrade-open, nil-limiter
  pass-through, empty-key skip, IP-key extraction (XFF +
  RemoteAddr), Retry-After minimum clamp. The Lua/Redis path itself
  is covered by the demo step.

## Test plan

- [x] `make verify` — fmt + vet + lint + gosec + race tests + openapi-check.
- [x] `make demo` — all 7 steps pass; app log shows
  `auth-token rate limiter ready burst=5 rate=1`:
  ```
  DSN-026   REST create + read via generate…  pass    225ms
  DSN-016   Kafka command → product_quant…    pass  7.145s
  DSN-017   Duplicate Kafka command applied…  pass    140ms
  DSN-018   Catalog enrichment via outbound…  pass    101ms
  DSN-019   REST Idempotency-Key replay + c…  pass    111ms
  DSN-020   Redis cache: second read is a h…  pass    144ms
  DSN-021b  Auth-token burst trips rate lim…  pass    114ms
  ```

## Notes

- Per-authenticated-user keying (the second bucket type the original
  DSN-021 mentions) is intentionally deferred: the only protected
  route today is the inventory write path, which is already covered
  by DSN-019's idempotency middleware. SEC-007 is the right home for
  per-route + per-identity tuning.
- The `Retry-After` header is clamped to a 1-second minimum so a
  sub-second backoff doesn't show up as `Retry-After: 0` and invite
  clients to bash on the endpoint.
- 5xx responses are not cached; the rate limiter consumes a token
  regardless of upstream outcome (the bucket protects against
  brute-force, not just against successful logins).
- One sub-ticket of DSN-021 remaining after this: **DSN-021c**
  (replace `hashicorp/golang-lru` user cache with Redis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)