### PR TITLE
SEC-005: document TLS posture and add HSTS + optional in-process TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,34 @@ The TS step shells out to `npx openapi-typescript@7` — it needs Node
 locally and is intentionally out of CI's Go-only matrix. Reviewers spot
 TS drift by hand for now.
 
+### TLS termination
+
+By default the HTTP server binds plaintext and TLS is terminated
+upstream by an ingress controller, service-mesh sidecar, or local-dev
+reverse proxy. The Caddy service in
+[docker-compose.yml](docker-compose.yml) demonstrates this locally:
+hit `https://localhost:8443` and Caddy reverse-proxies plaintext to
+the app on the compose network.
+
+The service can also serve HTTPS itself for single-host deployments
+without a terminator:
+
+| env var | default | meaning |
+| --- | --- | --- |
+| `GME_TLS_ENABLED` | `false` | When `true`, serve HTTPS via `ListenAndServeTLS`. |
+| `GME_TLS_CERTFILE` | *empty* | Path to a PEM cert (required when `tls.enabled=true`). |
+| `GME_TLS_KEYFILE` | *empty* | Path to the matching PEM private key. |
+
+The in-process TLS profile is TLS 1.2+ with the Mozilla "intermediate"
+AEAD cipher list. An [HSTS middleware](internal/platform/httpx/hsts.go)
+sets `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+on responses to requests that arrived over TLS — either directly (
+`r.TLS` non-nil) or via `X-Forwarded-Proto: https` from a terminator.
+Plaintext responses get no header.
+
+See [docs/deployment.md](docs/deployment.md) for the full deployment
+posture and production checklist.
+
 ### Rate limiting (auth-token)
 
 `/auth/token` is throttled by a distributed token-bucket rate

--- a/api/client/v1/client.gen.go
+++ b/api/client/v1/client.gen.go
@@ -102,6 +102,7 @@ type EnvResponse struct {
 	Redis       *ConfigRedisConfig       `json:"redis,omitempty"`
 	Revision    *ConfigStringConfig      `json:"revision,omitempty"`
 	Sha1Version *ConfigStringConfig      `json:"sha1Version,omitempty"`
+	Tls         *ConfigTLSConfig         `json:"tls,omitempty"`
 }
 
 // FieldProblem defines model for FieldProblem.
@@ -325,6 +326,14 @@ type ConfigStringConfig struct {
 	Default     *string `json:"default,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Value       *string `json:"value,omitempty"`
+}
+
+// ConfigTLSConfig defines model for config.TLSConfig.
+type ConfigTLSConfig struct {
+	CertFile    *ConfigStringConfig `json:"certFile,omitempty"`
+	Description *string             `json:"description,omitempty"`
+	Enabled     *ConfigBoolConfig   `json:"enabled,omitempty"`
+	KeyFile     *ConfigStringConfig `json:"keyFile,omitempty"`
 }
 
 // InternalUserCreateUserRequestDto defines model for internal_user.CreateUserRequestDto.

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,20 @@ type Config struct {
 	Redis       RedisConfig       `json:"redis"       yaml:"redis"`
 	RateLimit   RateLimitConfig   `json:"rateLimit"   yaml:"rateLimit"`
 	Docs        DocsConfig        `json:"docs"        yaml:"docs"`
+	TLS         TLSConfig         `json:"tls"         yaml:"tls"`
+}
+
+// TLSConfig drives SEC-005. In production TLS is terminated by an
+// ingress controller or sidecar and the service binds plaintext on a
+// private port. The optional fields below let single-host deployments
+// (or local dev without a terminator) serve HTTPS directly by pointing
+// at a PEM cert/key pair. An empty CertFile/KeyFile with Enabled=true
+// is a configuration error and fails fast at startup.
+type TLSConfig struct {
+	Enabled     BoolConfig   `json:"enabled"     yaml:"enabled"`
+	CertFile    StringConfig `json:"certFile"    yaml:"certFile"`
+	KeyFile     StringConfig `json:"keyFile"     yaml:"keyFile"    sensitive:"true"`
+	Description string       `json:"description" yaml:"description"`
 }
 
 // RedisConfig holds the DSN-020 Redis connection knobs. An empty URL
@@ -231,6 +245,10 @@ func init() {
 
 	viper.SetDefault("docs.enabled", def.Docs.Enabled.Default)
 
+	viper.SetDefault("tls.enabled", def.TLS.Enabled.Default)
+	viper.SetDefault("tls.certFile", def.TLS.CertFile.Default)
+	viper.SetDefault("tls.keyFile", def.TLS.KeyFile.Default)
+
 	viper.SetDefault("config.print", def.Config.Print.Default)
 	viper.SetDefault("config.source", def.Config.Source.Default)
 
@@ -295,6 +313,9 @@ func bindSensitiveEnv() {
 		"redis.userCacheTtlSeconds",
 		"rateLimit.authRatePerSecond",
 		"rateLimit.authBurst",
+		"tls.enabled",
+		"tls.certFile",
+		"tls.keyFile",
 	} {
 		// Errors here would mean a programming error in the key list —
 		// viper.BindEnv only fails on empty input.
@@ -592,6 +613,11 @@ func setupDefaults(config *Config) {
 	config.Redis.URL = StringConfig{Value: "", Default: "", Description: "Redis connection URL (redis://host:port/db). Empty disables the cache."}
 	config.Redis.CacheTTLMinutes = IntConfig{Value: 5, Default: 5, Description: "TTL for cached ProductInventory entries, in minutes. Short by default so missed invalidations self-heal."}
 	config.Redis.UserCacheTTLSeconds = IntConfig{Value: 60, Default: 60, Description: "TTL for cached User rows, in seconds. Short so admin/role revocations propagate without explicit cache-bust."}
+
+	config.TLS.Description = "SEC-005: optional in-process TLS termination. Production deployments terminate TLS at the ingress/sidecar and leave Enabled=false; set Enabled=true with cert/key paths for standalone hosts."
+	config.TLS.Enabled = BoolConfig{Value: false, Default: false, Description: "Serve HTTPS directly via http.Server.ListenAndServeTLS. Default false; production should terminate TLS upstream."}
+	config.TLS.CertFile = StringConfig{Value: "", Default: "", Description: "Path to a PEM-encoded TLS certificate (or chain). Required when tls.enabled is true."}
+	config.TLS.KeyFile = StringConfig{Value: "", Default: "", Description: "Path to the PEM-encoded private key matching tls.certFile. Required when tls.enabled is true. Supply via GME_TLS_KEYFILE."}
 
 	config.RateLimit.Description = "DSN-021b: per-IP rate limit for /auth/token (brute-force throttle). Requires redis.url; disabled when Redis isn't configured."
 	config.RateLimit.AuthRatePerSecond = FloatConfig{Value: 1.0, Default: 1.0, Description: "Token refill rate (tokens/sec) for the /auth/token bucket."}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,28 @@ services:
     # steps (cmd/demo/main.go: waitReady), so the gate is enforced
     # there rather than via Docker's HEALTHCHECK.
 
+  caddy:
+    # SEC-005: local-dev TLS terminator. Caddy listens on :443 with a
+    # self-signed cert (`tls internal`) and reverse-proxies plaintext
+    # to the app on the compose network. This mirrors the prod
+    # topology (ingress/sidecar handles TLS, the service binds
+    # plaintext on a private port) so HSTS middleware,
+    # X-Forwarded-Proto branches, and any TLS-conditional logic
+    # exercise the same code path locally. Browse to
+    # https://localhost:8443 (accept the self-signed warning) or curl
+    # with -k. The plain app port (8080) is still exposed for
+    # debugging without going through Caddy.
+    image: caddy:2-alpine
+    depends_on:
+      app:
+        condition: service_started
+    ports:
+      - "8443:443"
+    volumes:
+      - ./scripts/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
   demo:
     # DSN-015: orchestrator that runs each capability step end-to-end
     # against the live app and prints a summary table. Exits 0 on
@@ -193,3 +215,9 @@ services:
     # the demo service's log stream; the app keeps running for
     # interactive use afterwards.
     restart: "no"
+
+volumes:
+  # Caddy persists its locally-trusted CA cert across restarts so
+  # the dev cert stays stable instead of being regenerated each boot.
+  caddy_data:
+  caddy_config:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,105 @@
+# Deployment
+
+This document describes how go-micro-example expects to be deployed,
+with a particular focus on TLS termination — the topic SEC-005 was
+filed against.
+
+## TLS termination
+
+**The service binds plaintext.** In production, TLS is terminated
+upstream by the ingress controller (or a sidecar like Envoy / Linkerd
+proxy) and the service listens on a private port that only the
+terminator can reach. The reasons for this split:
+
+- Certificate rotation is the terminator's responsibility, not the
+  application's. Rotating an in-process listener requires a restart
+  or a hot-reload path; rotating at the ingress is a routine ops task.
+- The same posture lets us run mTLS between proxies (or service-mesh
+  sidecars) without complicating application code.
+- Decoupling lets the app survive cert-store and TLS-library churn
+  without code changes.
+
+### Standalone HTTPS (optional)
+
+For deployments without a terminator — a single-host VM, a one-off
+appliance, or a developer who wants to test HTTPS without compose —
+the service can serve HTTPS directly:
+
+```yaml
+tls:
+  enabled: true
+  certFile: /etc/go-micro-example/tls/server.crt
+  keyFile:  /etc/go-micro-example/tls/server.key
+```
+
+Or via env:
+
+```
+GME_TLS_ENABLED=true
+GME_TLS_CERTFILE=/etc/go-micro-example/tls/server.crt
+GME_TLS_KEYFILE=/etc/go-micro-example/tls/server.key
+```
+
+When `tls.enabled=true`:
+
+- The HTTP server uses `ListenAndServeTLS` with the configured cert/key.
+- The `tls.Config` enforces TLS 1.2+ and the Mozilla "intermediate"
+  AEAD cipher list (TLS 1.3 cipher suites and curves are fixed by Go).
+- The service fails to start if `tls.certFile` or `tls.keyFile` is
+  empty — a misconfiguration that would otherwise silently serve
+  cleartext.
+
+`tls.enabled=false` (the default) is the production posture; pair it
+with a TLS terminator out in front of the service.
+
+## HSTS
+
+The service unconditionally mounts an HSTS middleware
+([internal/platform/httpx/hsts.go](../internal/platform/httpx/hsts.go))
+that emits `Strict-Transport-Security` on responses to requests that
+arrived over TLS. The detection is:
+
+- `r.TLS != nil` — request hit the in-process TLS listener directly, **or**
+- `X-Forwarded-Proto: https` — a TLS terminator handled the handshake
+  and forwarded the request as plaintext.
+
+Plaintext requests get no header (browsers discard HSTS over HTTP, and
+emitting it makes local-dev logs noisier without buying any security).
+
+The default value is `max-age=31536000; includeSubDomains` —
+Mozilla's intermediate profile and the minimum the HSTS preload list
+requires. `preload` is **not** enabled by default; turn it on only
+once every subdomain has been verified HTTPS-only.
+
+## Local development
+
+`docker-compose.yml` ships a [Caddy](https://caddyserver.com/)
+service that mirrors the prod topology: Caddy listens on `:443` with
+a self-signed cert (`tls internal`) and reverse-proxies plaintext to
+the app on the compose network. The app continues to expose its
+plain `:8080` listener for direct debugging.
+
+```sh
+docker compose up --build
+# https://localhost:8443/   (Caddy → app, self-signed cert; -k or trust the CA)
+# http://localhost:8080/    (app direct; no TLS)
+```
+
+The Caddyfile lives at
+[scripts/caddy/Caddyfile](../scripts/caddy/Caddyfile). The Caddy
+container persists its locally-generated CA in a named volume so the
+cert stays stable across restarts — `docker compose down -v` wipes
+it.
+
+## Production checklist
+
+- TLS terminator (ingress / sidecar) handles certs and sits in front
+  of the service.
+- The service binds on a private port; only the terminator can reach
+  it.
+- The terminator forwards `X-Forwarded-Proto: https` so the HSTS
+  middleware engages.
+- `tls.enabled` is left at its default (`false`) unless the
+  deployment intentionally serves HTTPS directly.
+- The terminator's TLS profile is at least as strict as the in-process
+  one: TLS 1.2+, AEAD ciphers only, modern curves.

--- a/internal/app/openapi.json
+++ b/internal/app/openapi.json
@@ -96,6 +96,9 @@
                     },
                     "sha1Version": {
                         "$ref": "#/components/schemas/config.StringConfig"
+                    },
+                    "tls": {
+                        "$ref": "#/components/schemas/config.TLSConfig"
                     }
                 },
                 "type": "object"
@@ -570,6 +573,23 @@
                     },
                     "value": {
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "config.TLSConfig": {
+                "properties": {
+                    "certFile": {
+                        "$ref": "#/components/schemas/config.StringConfig"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "enabled": {
+                        "$ref": "#/components/schemas/config.BoolConfig"
+                    },
+                    "keyFile": {
+                        "$ref": "#/components/schemas/config.StringConfig"
                     }
                 },
                 "type": "object"

--- a/internal/app/openapi.yaml
+++ b/internal/app/openapi.yaml
@@ -68,6 +68,8 @@ components:
           $ref: '#/components/schemas/config.StringConfig'
         sha1Version:
           $ref: '#/components/schemas/config.StringConfig'
+        tls:
+          $ref: '#/components/schemas/config.TLSConfig'
       type: object
     FieldProblem:
       properties:
@@ -377,6 +379,17 @@ components:
           type: string
         value:
           type: string
+      type: object
+    config.TLSConfig:
+      properties:
+        certFile:
+          $ref: '#/components/schemas/config.StringConfig'
+        description:
+          type: string
+        enabled:
+          $ref: '#/components/schemas/config.BoolConfig'
+        keyFile:
+          $ref: '#/components/schemas/config.StringConfig'
       type: object
     internal_user.CreateUserRequestDto:
       properties:

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -66,6 +66,10 @@ func ConfigureRouter(cfg *config.Config, invSvc inventory.InventoryService, resS
 	}))
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
+	// HSTS only emits a header on TLS requests (direct or via
+	// X-Forwarded-Proto: https), so mounting it unconditionally is
+	// safe for plaintext local dev too.
+	r.Use(httpx.HSTS(httpx.HSTSOptions{IncludeSubDomains: true}))
 	// otelchi mounts before Metrics/Logging so the span covers
 	// both. The chi route pattern (e.g. /api/v1/inventory/{sku})
 	// is the span name, which is what you want for grouping —

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -120,7 +121,34 @@ func newWith(cfg *config.Config, deps Deps) *Server {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+	if cfg.TLS.Enabled.Value {
+		srv.TLSConfig = modernTLSConfig()
+	}
 	return &Server{cfg: cfg, deps: deps, http: srv}
+}
+
+// modernTLSConfig returns the TLS settings the service uses when it
+// terminates HTTPS itself. The profile matches Mozilla's
+// "intermediate" recommendation: TLS 1.2+ only, AEAD cipher suites,
+// forward-secret key exchange. TLS 1.3 cipher suites and curves are
+// fixed by Go and need no explicit listing.
+func modernTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+		},
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		},
+	}
 }
 
 // Handler exposes the chi router so tests can hit it via httptest
@@ -133,10 +161,27 @@ func (s *Server) Handler() http.Handler { return s.http.Handler }
 func (s *Server) Run(ctx context.Context) error {
 	start := time.Now()
 
+	if s.cfg.TLS.Enabled.Value {
+		if s.cfg.TLS.CertFile.Value == "" || s.cfg.TLS.KeyFile.Value == "" {
+			return fmt.Errorf("tls.enabled=true requires tls.certFile and tls.keyFile")
+		}
+	}
+
 	serveErr := make(chan error, 1)
 	go func() {
-		log.Info().Str("port", s.cfg.Port.Value).Int64("startTimeMs", time.Since(start).Milliseconds()).Msg("listening")
-		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		var err error
+		if s.cfg.TLS.Enabled.Value {
+			log.Info().
+				Str("port", s.cfg.Port.Value).
+				Str("certFile", s.cfg.TLS.CertFile.Value).
+				Int64("startTimeMs", time.Since(start).Milliseconds()).
+				Msg("listening (TLS)")
+			err = s.http.ListenAndServeTLS(s.cfg.TLS.CertFile.Value, s.cfg.TLS.KeyFile.Value)
+		} else {
+			log.Info().Str("port", s.cfg.Port.Value).Int64("startTimeMs", time.Since(start).Milliseconds()).Msg("listening")
+			err = s.http.ListenAndServe()
+		}
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serveErr <- err
 		}
 		close(serveErr)

--- a/internal/platform/httpx/hsts.go
+++ b/internal/platform/httpx/hsts.go
@@ -1,0 +1,61 @@
+package httpx
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// defaultHSTSMaxAge is one year in seconds, which is the value the
+// HSTS preload list requires and what Mozilla's Server Side TLS
+// "intermediate" profile recommends. Shorter values still satisfy the
+// header spec but lose preload eligibility.
+const defaultHSTSMaxAge = 31536000
+
+// HSTSOptions tunes the Strict-Transport-Security header. Defaults
+// match Mozilla's intermediate TLS profile: one-year max-age,
+// includeSubDomains on, preload off (callers opt in once they've
+// confirmed every subdomain is HTTPS-only).
+type HSTSOptions struct {
+	MaxAgeSeconds     int
+	IncludeSubDomains bool
+	Preload           bool
+}
+
+// HSTS returns middleware that emits Strict-Transport-Security only on
+// requests that arrived over TLS — either directly (r.TLS != nil) or
+// through an HTTPS-terminating proxy that set X-Forwarded-Proto: https.
+// The header is meaningless (and discarded by browsers) on plaintext
+// responses, so we don't bother emitting it there; this also keeps
+// local plaintext dev free of header noise.
+func HSTS(opts HSTSOptions) func(http.Handler) http.Handler {
+	if opts.MaxAgeSeconds <= 0 {
+		opts.MaxAgeSeconds = defaultHSTSMaxAge
+	}
+	value := buildHSTSValue(opts)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isHTTPSRequest(r) {
+				w.Header().Set("Strict-Transport-Security", value)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isHTTPSRequest(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return r.Header.Get("X-Forwarded-Proto") == "https"
+}
+
+func buildHSTSValue(opts HSTSOptions) string {
+	v := "max-age=" + strconv.Itoa(opts.MaxAgeSeconds)
+	if opts.IncludeSubDomains {
+		v += "; includeSubDomains"
+	}
+	if opts.Preload {
+		v += "; preload"
+	}
+	return v
+}

--- a/internal/platform/httpx/hsts_test.go
+++ b/internal/platform/httpx/hsts_test.go
@@ -1,0 +1,77 @@
+package httpx_test
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sksmith/go-micro-example/internal/platform/httpx"
+)
+
+func TestHSTS(t *testing.T) {
+	noop := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	tests := []struct {
+		name   string
+		opts   httpx.HSTSOptions
+		prep   func(*http.Request)
+		header string
+	}{
+		{
+			name:   "plaintext request omits header",
+			opts:   httpx.HSTSOptions{IncludeSubDomains: true},
+			prep:   func(*http.Request) {},
+			header: "",
+		},
+		{
+			name: "direct TLS request emits default header",
+			opts: httpx.HSTSOptions{IncludeSubDomains: true},
+			prep: func(r *http.Request) {
+				r.TLS = &tls.ConnectionState{}
+			},
+			header: "max-age=31536000; includeSubDomains",
+		},
+		{
+			name: "X-Forwarded-Proto=https triggers header",
+			opts: httpx.HSTSOptions{IncludeSubDomains: true, Preload: true},
+			prep: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "https")
+			},
+			header: "max-age=31536000; includeSubDomains; preload",
+		},
+		{
+			name: "X-Forwarded-Proto=http does not trigger header",
+			opts: httpx.HSTSOptions{},
+			prep: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "http")
+			},
+			header: "",
+		},
+		{
+			name: "custom max-age overrides default",
+			opts: httpx.HSTSOptions{MaxAgeSeconds: 60},
+			prep: func(r *http.Request) {
+				r.TLS = &tls.ConnectionState{}
+			},
+			header: "max-age=60",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+			tc.prep(req)
+			rec := httptest.NewRecorder()
+
+			httpx.HSTS(tc.opts)(noop).ServeHTTP(rec, req)
+
+			got := rec.Header().Get("Strict-Transport-Security")
+			if got != tc.header {
+				t.Errorf("Strict-Transport-Security got=%q want=%q", got, tc.header)
+			}
+		})
+	}
+}

--- a/scripts/caddy/Caddyfile
+++ b/scripts/caddy/Caddyfile
@@ -1,0 +1,27 @@
+# SEC-005: local-dev HTTPS terminator.
+#
+# `tls internal` makes Caddy generate (and trust, inside its own
+# container) a self-signed cert for the listed host. Browsers will
+# warn on first visit because the cert chain is not in the host
+# trust store — that's expected for compose-based dev. The point is
+# to match prod's topology (HTTPS in, plaintext to the app on a
+# private port) so headers like HSTS and middleware that branch on
+# r.TLS / X-Forwarded-Proto see the same shape locally.
+#
+# In prod, replace `tls internal` with a real cert (file paths or
+# ACME), and replace `:443` with whatever the ingress fronts.
+:443 {
+	tls internal
+
+	# Forward to the app over the compose-internal network. The
+	# trailing :8080 is the plaintext listener inside the app
+	# container. reverse_proxy sets X-Forwarded-* automatically.
+	reverse_proxy app:8080
+
+	# Ask Caddy to log access in JSON so it lines up with the app's
+	# structured-log mode when both are tailed together.
+	log {
+		output stdout
+		format json
+	}
+}

--- a/web/src/api/schema.ts
+++ b/web/src/api/schema.ts
@@ -704,6 +704,7 @@ export interface components {
             redis?: components["schemas"]["config.RedisConfig"];
             revision?: components["schemas"]["config.StringConfig"];
             sha1Version?: components["schemas"]["config.StringConfig"];
+            tls?: components["schemas"]["config.TLSConfig"];
         };
         FieldProblem: {
             detail?: string;
@@ -867,6 +868,12 @@ export interface components {
             default?: string;
             description?: string;
             value?: string;
+        };
+        "config.TLSConfig": {
+            certFile?: components["schemas"]["config.StringConfig"];
+            description?: string;
+            enabled?: components["schemas"]["config.BoolConfig"];
+            keyFile?: components["schemas"]["config.StringConfig"];
         };
         "internal_user.CreateUserRequestDto": {
             isAdmin?: boolean;


### PR DESCRIPTION
## Summary

- Documents the production TLS posture (terminated upstream by ingress/sidecar; service binds plaintext) in `docs/deployment.md` and a new README subsection.
- Adds optional in-process TLS for deployments without a terminator: `GME_TLS_ENABLED`, `GME_TLS_CERTFILE`, `GME_TLS_KEYFILE`. When on, `Server.Run` uses `ListenAndServeTLS` with a Mozilla-intermediate `tls.Config` (TLS 1.2+, AEAD-only cipher list, modern curves). Empty cert/key + `Enabled=true` fails fast.
- Adds an HSTS middleware (`internal/platform/httpx/hsts.go`) that emits `Strict-Transport-Security: max-age=31536000; includeSubDomains` only on requests that arrived over TLS (direct `r.TLS != nil` or `X-Forwarded-Proto: https`). Plaintext responses get no header.
- Adds a Caddy reverse-proxy service to `docker-compose.yml` (`tls internal`, listens on `:8443`, proxies plaintext to the app) so local dev mirrors the prod topology.

## Ticket

[plan/SEC-005-tls-everywhere.md](plan/SEC-005-tls-everywhere.md)

## Acceptance criteria

- [x] Documented decision: TLS terminated by ingress/sidecar in production; the service binds plaintext on loopback or a private port. See `docs/deployment.md`.
- [x] Optional `tls.enabled` / `tls.certFile` / `tls.keyFile` flags (env: `GME_TLS_*`) for environments without a terminator.
- [x] TLS 1.2+ only, modern cipher list, HSTS header set when behind TLS (direct or via `X-Forwarded-Proto: https`).
- [x] Local-dev compose adds a self-signed reverse proxy (Caddy) so devs hit HTTPS, matching prod.

## Non-obvious choices

- **HSTS is unconditionally mounted**, but only emits the header when the request was TLS. Mounting it always keeps the middleware stack simple and makes the prod-vs-local difference a single header, not a code branch.
- **`tls.enabled` defaults to `false`.** Production already terminates upstream; flipping the default would silently break those deployments.
- **Caddy uses `tls internal` (self-signed CA persisted in a named volume).** No host trust-store munging required; browsers warn on first visit, `curl -k` works, and the CA is stable across restarts. `docker compose down -v` wipes it.
- **TS schema and Go OpenAPI client regenerated** because the `/env` endpoint surfaces the new `TLSConfig` struct.

## Out-of-scope follow-ups (not introduced here)

- `govulncheck` reports 23 stdlib vulnerabilities all stemming from Go 1.25 needing 1.25.3 — same set as on `master`. The new `ListenAndServeTLS` call adds traces (#5/#6/#7) to vulns already triggered by AMQP/stub-catalog/Metrics call paths; it does not introduce new vulnerabilities. A separate dependency-bump ticket (DEP-011 / DEP-012 territory) should cover the toolchain upgrade.

## Test plan

- [x] `make verify` (fmt + vet + lint + gosec + race tests + openapi-check)
- [x] New `hsts_test.go` covers: plaintext omits header, direct TLS emits default, `X-Forwarded-Proto: https` triggers header (with preload), `X-Forwarded-Proto: http` does not, custom `MaxAgeSeconds`.
- [ ] Manual: `docker compose up --build`, hit `https://localhost:8443/live` (self-signed cert), confirm `Strict-Transport-Security` header is present; hit `http://localhost:8080/live` directly, confirm header is absent.
- [ ] Manual: generate a self-signed cert, set `GME_TLS_ENABLED=true GME_TLS_CERTFILE=... GME_TLS_KEYFILE=...`, run the server, confirm it serves HTTPS directly and emits HSTS.