### PR TITLE
SEC-006: replace wildcarded CORS with explicit exact-origin list

### DIFF
--- a/api/client/v1/client.gen.go
+++ b/api/client/v1/client.gen.go
@@ -90,6 +90,7 @@ type EnvResponse struct {
 	BuildTime   *ConfigStringConfig      `json:"buildTime,omitempty"`
 	Catalog     *ConfigCatalogConfig     `json:"catalog,omitempty"`
 	Config      *ConfigConfigSource      `json:"config,omitempty"`
+	Cors        *ConfigCORSConfig        `json:"cors,omitempty"`
 	Db          *ConfigDbConfig          `json:"db,omitempty"`
 	Docs        *ConfigDocsConfig        `json:"docs,omitempty"`
 	Idempotency *ConfigIdempotencyConfig `json:"idempotency,omitempty"`
@@ -173,6 +174,13 @@ type ConfigBoolConfig struct {
 	Default     *bool   `json:"default,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Value       *bool   `json:"value,omitempty"`
+}
+
+// ConfigCORSConfig defines model for config.CORSConfig.
+type ConfigCORSConfig struct {
+	AllowCredentials *ConfigBoolConfig   `json:"allowCredentials,omitempty"`
+	AllowedOrigins   *ConfigStringConfig `json:"allowedOrigins,omitempty"`
+	Description      *string             `json:"description,omitempty"`
 }
 
 // ConfigCatalogConfig defines model for config.CatalogConfig.

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,22 @@ type Config struct {
 	RateLimit   RateLimitConfig   `json:"rateLimit"   yaml:"rateLimit"`
 	Docs        DocsConfig        `json:"docs"        yaml:"docs"`
 	TLS         TLSConfig         `json:"tls"         yaml:"tls"`
+	CORS        CORSConfig        `json:"cors"        yaml:"cors"`
+}
+
+// CORSConfig drives SEC-006. The previous implementation hard-coded
+// wildcarded origins (http://localhost:*, https://*.seanksmith.me)
+// together with AllowCredentials=true — a footgun because a credentialed
+// request from any matching subdomain (including one that doesn't exist
+// yet) would be reflected. The list is now an explicit, comma-separated
+// set of exact origins driven by config/env. An empty list disables
+// CORS entirely (no Access-Control-Allow-Origin header on any request)
+// which is the right posture for a service that fronts a same-origin
+// UI or only serves first-party clients.
+type CORSConfig struct {
+	AllowedOrigins   StringConfig `json:"allowedOrigins"   yaml:"allowedOrigins"`
+	AllowCredentials BoolConfig   `json:"allowCredentials" yaml:"allowCredentials"`
+	Description      string       `json:"description"      yaml:"description"`
 }
 
 // TLSConfig drives SEC-005. In production TLS is terminated by an
@@ -316,6 +332,8 @@ func bindSensitiveEnv() {
 		"tls.enabled",
 		"tls.certFile",
 		"tls.keyFile",
+		"cors.allowedOrigins",
+		"cors.allowCredentials",
 	} {
 		// Errors here would mean a programming error in the key list —
 		// viper.BindEnv only fails on empty input.
@@ -613,6 +631,10 @@ func setupDefaults(config *Config) {
 	config.Redis.URL = StringConfig{Value: "", Default: "", Description: "Redis connection URL (redis://host:port/db). Empty disables the cache."}
 	config.Redis.CacheTTLMinutes = IntConfig{Value: 5, Default: 5, Description: "TTL for cached ProductInventory entries, in minutes. Short by default so missed invalidations self-heal."}
 	config.Redis.UserCacheTTLSeconds = IntConfig{Value: 60, Default: 60, Description: "TTL for cached User rows, in seconds. Short so admin/role revocations propagate without explicit cache-bust."}
+
+	config.CORS.Description = "SEC-006: browser CORS policy. AllowedOrigins is a comma-separated list of EXACT origins (scheme://host[:port]); wildcards are intentionally not supported. Empty disables CORS entirely. AllowCredentials reflects only matching origins."
+	config.CORS.AllowedOrigins = StringConfig{Value: "http://localhost:8080,https://localhost", Default: "http://localhost:8080,https://localhost", Description: "Comma-separated exact origins permitted to make credentialed cross-origin requests. Empty disables CORS. Override in prod via GME_CORS_ALLOWEDORIGINS with your real front-end origins."}
+	config.CORS.AllowCredentials = BoolConfig{Value: true, Default: true, Description: "Send Access-Control-Allow-Credentials: true for matching origins. Safe only because AllowedOrigins is an exact list — never set this true alongside a wildcard origin."}
 
 	config.TLS.Description = "SEC-005: optional in-process TLS termination. Production deployments terminate TLS at the ingress/sidecar and leave Enabled=false; set Enabled=true with cert/key paths for standalone hosts."
 	config.TLS.Enabled = BoolConfig{Value: false, Default: false, Description: "Serve HTTPS directly via http.Server.ListenAndServeTLS. Default false; production should terminate TLS upstream."}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -91,6 +91,51 @@ container persists its locally-generated CA in a named volume so the
 cert stays stable across restarts — `docker compose down -v` wipes
 it.
 
+## CORS
+
+The service supports browser cross-origin requests through an
+explicit, environment-driven allowlist. The previous configuration
+combined wildcarded origins (`http://localhost:*`,
+`https://*.seanksmith.me`) with `Access-Control-Allow-Credentials:
+true`, which is a footgun — a credentialed fetch from any subdomain
+that ever exists (or is taken over) would have succeeded. SEC-006
+replaces it with exact-match origins:
+
+```yaml
+cors:
+  allowedOrigins: "https://app.example.com,https://admin.example.com"
+  allowCredentials: true
+```
+
+Or via env (overrides the file):
+
+```sh
+GME_CORS_ALLOWEDORIGINS=https://app.example.com,https://admin.example.com
+GME_CORS_ALLOWCREDENTIALS=true
+```
+
+Notes:
+
+- Entries are exact origins (`scheme://host[:port]`). Wildcards are
+  intentionally not supported — any `*` in an entry will simply fail
+  to match any real origin.
+- An empty `allowedOrigins` disables CORS entirely: the middleware is
+  not mounted and no `Access-Control-Allow-Origin` header is emitted.
+  This is the right default for a same-origin UI or a first-party-only
+  API.
+- `allowCredentials: true` is safe only because the list is exact.
+  Never re-introduce wildcard origins while credentials are allowed.
+- `X-CSRF-Token` was dropped from `Access-Control-Allow-Headers`:
+  SEC-002c moved the project to bearer-token auth, and no CSRF
+  strategy currently issues or validates that header. Re-add when a
+  real CSRF mechanism lands.
+
+The defaults (`http://localhost:8080,https://localhost`) cover the
+plain app listener and the Caddy HTTPS terminator described above, so
+local dev works out of the box. Production deployments should
+override `GME_CORS_ALLOWEDORIGINS` with the real front-end origins
+(or set it to an empty string if no cross-origin clients exist).
+
 ## Production checklist
 
 - TLS terminator (ingress / sidecar) handles certs and sits in front
@@ -103,3 +148,5 @@ it.
   deployment intentionally serves HTTPS directly.
 - The terminator's TLS profile is at least as strict as the in-process
   one: TLS 1.2+, AEAD ciphers only, modern curves.
+- `GME_CORS_ALLOWEDORIGINS` is set to the explicit front-end origins
+  (or left empty for first-party-only APIs); wildcards are never used.

--- a/internal/app/openapi.json
+++ b/internal/app/openapi.json
@@ -61,6 +61,9 @@
                     "config": {
                         "$ref": "#/components/schemas/config.ConfigSource"
                     },
+                    "cors": {
+                        "$ref": "#/components/schemas/config.CORSConfig"
+                    },
                     "db": {
                         "$ref": "#/components/schemas/config.DbConfig"
                     },
@@ -247,6 +250,20 @@
                     },
                     "value": {
                         "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "config.CORSConfig": {
+                "properties": {
+                    "allowCredentials": {
+                        "$ref": "#/components/schemas/config.BoolConfig"
+                    },
+                    "allowedOrigins": {
+                        "$ref": "#/components/schemas/config.StringConfig"
+                    },
+                    "description": {
+                        "type": "string"
                     }
                 },
                 "type": "object"

--- a/internal/app/openapi.yaml
+++ b/internal/app/openapi.yaml
@@ -44,6 +44,8 @@ components:
           $ref: '#/components/schemas/config.CatalogConfig'
         config:
           $ref: '#/components/schemas/config.ConfigSource'
+        cors:
+          $ref: '#/components/schemas/config.CORSConfig'
         db:
           $ref: '#/components/schemas/config.DbConfig'
         docs:
@@ -168,6 +170,15 @@ components:
           type: string
         value:
           type: boolean
+      type: object
+    config.CORSConfig:
+      properties:
+        allowCredentials:
+          $ref: '#/components/schemas/config.BoolConfig'
+        allowedOrigins:
+          $ref: '#/components/schemas/config.StringConfig'
+        description:
+          type: string
       type: object
     config.CatalogConfig:
       properties:

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -56,14 +57,25 @@ func ConfigureRouter(cfg *config.Config, invSvc inventory.InventoryService, resS
 	log.Info().Msg("configuring router...")
 	r := chi.NewRouter()
 
-	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*.seanksmith.me", "http://*.seanksmith.me", "http://localhost:*", "https://localhost:*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		ExposedHeaders:   []string{"Link"},
-		AllowCredentials: true,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
+	// SEC-006: CORS uses an explicit, environment-driven list of exact
+	// origins. AllowCredentials is only safe alongside an exact list,
+	// never a wildcard. An empty list disables CORS entirely: go-chi's
+	// cors handler with no allowed origins emits no
+	// Access-Control-Allow-Origin header, which is the right behavior
+	// for a same-origin or first-party-only deployment.
+	if origins := parseCORSOrigins(cfg.CORS.AllowedOrigins.Value); len(origins) > 0 {
+		r.Use(cors.Handler(cors.Options{
+			AllowedOrigins: origins,
+			AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+			// X-CSRF-Token removed: SEC-002c took the project to
+			// bearer-token auth, and no CSRF token strategy exists
+			// to back the header. Re-add only when a real one does.
+			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+			ExposedHeaders:   []string{"Link"},
+			AllowCredentials: cfg.CORS.AllowCredentials.Value,
+			MaxAge:           300, // Maximum value not ignored by any of major browsers
+		}))
+	}
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)
 	// HSTS only emits a header on TLS requests (direct or via
@@ -113,4 +125,23 @@ func ConfigureRouter(cfg *config.Config, invSvc inventory.InventoryService, resS
 	})
 
 	return r
+}
+
+// parseCORSOrigins splits the comma-separated cors.allowedOrigins
+// config value into a clean slice. Whitespace and empty entries are
+// dropped so a trailing comma or a "  " entry in YAML doesn't quietly
+// permit the empty-string origin (which go-chi's matcher would treat
+// as a wildcard).
+func parseCORSOrigins(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/internal/app/routes_test.go
+++ b/internal/app/routes_test.go
@@ -38,19 +38,30 @@ func newTestRouterWithSigner() (chi.Router, *user.MockUserService, *auth.Signer)
 }
 
 func TestCorsConfig(t *testing.T) {
+	// SEC-006: CORS now drives off an explicit comma-separated
+	// exact-origin list in config.cors.allowedOrigins. Defaults allow
+	// http://localhost:8080 + https://localhost; anything else — wildcards,
+	// suffix attacks, look-alike hostnames — must be denied.
 	tests := []struct {
 		origin string
 		want   string
 	}{
+		// Exact-match origins from the default config: reflected.
+		{origin: "http://localhost:8080", want: "http://localhost:8080"},
+		{origin: "https://localhost", want: "https://localhost"},
+
+		// Unlisted origins: no Access-Control-Allow-Origin.
 		{origin: "https://evilorigin.com", want: ""},
 		{origin: "http://evilorigin.com", want: ""},
-		{origin: "https://subdomain.seanksmith.me", want: "https://subdomain.seanksmith.me"},
-		{origin: "http://subdomain.seanksmith.me", want: "http://subdomain.seanksmith.me"},
-		{origin: "http://subdomain.seanksmith.evil.me", want: ""},
-		{origin: "http://localhost:8080", want: "http://localhost:8080"},
-		{origin: "http://localhost:3000", want: "http://localhost:3000"},
-		{origin: "https://localhost:8080", want: "https://localhost:8080"},
-		{origin: "https://localhost:3000", want: "https://localhost:3000"},
+
+		// Old wildcarded entries (https://*.seanksmith.me, http://localhost:*)
+		// must no longer match anything.
+		{origin: "https://subdomain.seanksmith.me", want: ""},
+		{origin: "http://subdomain.seanksmith.me", want: ""},
+		{origin: "http://localhost:3000", want: ""},
+		{origin: "https://localhost:8080", want: ""},
+
+		// Look-alike host that prefix-matched the old localhost wildcard.
 		{origin: "https://localhostevil:3000", want: ""},
 	}
 
@@ -75,8 +86,37 @@ func TestCorsConfig(t *testing.T) {
 
 		got := res.Header.Get("Access-Control-Allow-Origin")
 		if got != test.want {
-			t.Errorf("failed cors test got=[%v] want=[%v]", got, test.want)
+			t.Errorf("failed cors test origin=%q got=[%v] want=[%v]", test.origin, got, test.want)
 		}
+	}
+}
+
+func TestCorsDisabledWhenAllowedOriginsEmpty(t *testing.T) {
+	// SEC-006: empty config.cors.allowedOrigins must skip the CORS
+	// middleware entirely — no Access-Control-Allow-Origin header on
+	// any request, regardless of the Origin sent.
+	cfg := config.LoadDefaults()
+	cfg.CORS.AllowedOrigins.Value = ""
+	invSvc, resSvc, usrSvc := getMocks()
+	signer, err := auth.NewSigner(nil, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := app.ConfigureRouter(cfg, invSvc, resSvc, usrSvc, signer, nil, nil, nil, nil)
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	req, err := http.NewRequest("GET", ts.URL+app.ApiPath+app.InventoryPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Origin", "http://localhost:8080")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := res.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin when CORS disabled, got %q", got)
 	}
 }
 

--- a/web/src/api/schema.ts
+++ b/web/src/api/schema.ts
@@ -692,6 +692,7 @@ export interface components {
             buildTime?: components["schemas"]["config.StringConfig"];
             catalog?: components["schemas"]["config.CatalogConfig"];
             config?: components["schemas"]["config.ConfigSource"];
+            cors?: components["schemas"]["config.CORSConfig"];
             db?: components["schemas"]["config.DbConfig"];
             docs?: components["schemas"]["config.DocsConfig"];
             idempotency?: components["schemas"]["config.IdempotencyConfig"];
@@ -753,6 +754,11 @@ export interface components {
             default?: boolean;
             description?: string;
             value?: boolean;
+        };
+        "config.CORSConfig": {
+            allowCredentials?: components["schemas"]["config.BoolConfig"];
+            allowedOrigins?: components["schemas"]["config.StringConfig"];
+            description?: string;
         };
         "config.CatalogConfig": {
             baseUrl?: components["schemas"]["config.StringConfig"];


### PR DESCRIPTION
## Summary

- Replace hard-coded `http://localhost:*` + `https://*.seanksmith.me` wildcards in [internal/app/routes.go](internal/app/routes.go) with a config-driven exact-origin list (`cors.allowedOrigins`, bound to `GME_CORS_ALLOWEDORIGINS`). Wildcards are intentionally unsupported.
- `Access-Control-Allow-Credentials` stays `true` but is now safe because the list is exact-match only; an empty list skips the CORS middleware entirely (no header on any request).
- Drop `X-CSRF-Token` from `Access-Control-Allow-Headers` — SEC-002c moved the project to bearer-token auth and no CSRF strategy issues or validates the header. Re-add when a real one lands.
- Document in [docs/deployment.md](docs/deployment.md) (defaults, env var, prod posture, why no wildcards).
- Update `TestCorsConfig` to assert the new policy + new `TestCorsDisabledWhenAllowedOriginsEmpty` for the empty-list path.

Ticket: `plan/SEC-006-cors-hardening.md`.

## Acceptance criteria

- [x] Allowed origins are an explicit, environment-driven list (no wildcards in prod).
- [x] `AllowCredentials: true` only when origins are exact-matched.
- [x] `X-CSRF-Token` removed — no CSRF strategy currently exists (SEC-002 / SEC-002c).
- [x] Tests assert that an unlisted origin receives no `Access-Control-Allow-Origin` header (and that the old wildcards no longer match).

## Notes

- `make verify` clean. `govulncheck ./...` reports 23 pre-existing Go-stdlib findings unrelated to this change (tracked separately — needs a toolchain bump; SEC-014 will wire `govulncheck` into `make verify` once that's resolved).
- The ticket's findings line referenced `api/api.go:33-41`, which DSN-028 moved to `internal/app/routes.go`. The change applies to the new location.
- No new direct dependency added.

## Test plan

- [x] `make verify` (fmt + vet + lint + sec + test-race + openapi-check)
- [x] `TestCorsConfig` — exact-match origins reflect; wildcards and look-alikes get no `Access-Control-Allow-Origin`
- [x] `TestCorsDisabledWhenAllowedOriginsEmpty` — empty config skips middleware entirely
- [ ] Reviewer: smoke-check `GME_CORS_ALLOWEDORIGINS` env override on a local boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)