### PR TITLE
SEC-014: wire govulncheck into make verify and CI hard-gate

### DIFF
--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -29,9 +29,11 @@ jobs:
         with:
           sarif_file: govulncheck.sarif
           category: govulncheck
-      # Until DEP-001 (Go toolchain) and DEP-002 (chi v4 -> v5) land,
-      # the 25 deferred CVEs from SEC-008 will keep firing here.
-      # Surface them in the Security tab but don't block PRs yet.
-      - name: Run govulncheck (text, soft-fail until DEP-001/DEP-002 land)
-        continue-on-error: true
+      # SEC-014: govulncheck is now a hard gate, matching `make verify`
+      # locally. DEP-001 and DEP-002 have landed and the go.mod toolchain
+      # pin is up to date, so the previously-deferred stdlib findings are
+      # cleared. A new finding here should block the merge — bump
+      # go.mod's toolchain directive (or the offending dependency) and
+      # the gate clears again.
+      - name: Run govulncheck (text)
         run: govulncheck ./...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHA1 := $(shell git rev-parse HEAD)
 NOW := $(shell date -u +'%Y-%m-%d_%TZ')
 GOBIN := $(shell go env GOPATH)/bin
 
-.PHONY: fmt vet lint sec test-race verify cover
+.PHONY: fmt vet lint sec vuln test-race verify cover
 fmt:
 	@echo "==> gofmt"
 	@out=$$(gofmt -l .); if [ -n "$$out" ]; then echo "$$out"; echo "files need gofmt"; exit 1; fi
@@ -20,11 +20,20 @@ sec:
 	@echo "==> gosec"
 	@command -v gosec >/dev/null 2>&1 && gosec -exclude-dir=api/client ./... || $(GOBIN)/gosec -exclude-dir=api/client ./...
 
+# SEC-014: govulncheck scans the build configuration against the Go
+# vuln DB. Stdlib findings track go.mod's toolchain directive, so a
+# stdlib finding here means the toolchain pin is stale (bump it and
+# the finding clears). Pinned in tools: to a known version for
+# reproducibility — bump intentionally, not via @latest drift.
+vuln:
+	@echo "==> govulncheck"
+	@command -v govulncheck >/dev/null 2>&1 && govulncheck ./... || $(GOBIN)/govulncheck ./...
+
 test-race:
 	@echo "==> go test -race"
 	go test -race -count=1 -timeout 60s ./...
 
-verify: fmt vet lint sec test-race openapi-check
+verify: fmt vet lint sec vuln test-race openapi-check
 	@echo "==> verify OK"
 
 cover:
@@ -58,6 +67,11 @@ tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install github.com/swaggo/swag/v2/cmd/swag@latest
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	# govulncheck is pinned (not @latest) so the tool surface that
+	# decides whether `make verify` passes is reproducible across
+	# developer machines and CI. Bump intentionally; the other tools
+	# above are still @latest pending a similar pass.
+	go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
 .PHONY: openapi clients clients-go clients-ts openapi-check
 openapi:

--- a/README.md
+++ b/README.md
@@ -554,13 +554,14 @@ exposed so you can run a single step in isolation:
 
 | Target | What it does |
 | --- | --- |
-| `make tools` | Installs `golangci-lint` and `gosec` into `$(go env GOPATH)/bin`. Run once before `make verify`, and re-run when bumping versions. |
+| `make tools` | Installs `golangci-lint`, `gosec`, and `govulncheck` (pinned) into `$(go env GOPATH)/bin`. Run once before `make verify`, and re-run when bumping versions. |
 | `make fmt` | Runs `gofmt -l .` and exits non-zero if any file needs formatting. Does not modify files — fix with `gofmt -w <file>`. |
 | `make vet` | Runs `go vet ./...`. |
 | `make lint` | Runs `golangci-lint run` with the project defaults. |
 | `make sec` | Runs `gosec ./...` (CWE-tagged static analysis). |
+| `make vuln` | Runs `govulncheck ./...` against the [Go vulnerability database](https://pkg.go.dev/vuln). Fails on any finding — stdlib findings are cleared by bumping `go.mod`'s `toolchain` directive. |
 | `make test-race` | Runs `go test -race -count=1 -timeout 60s ./...`. |
-| `make verify` | Runs `fmt`, `vet`, `lint`, `sec`, and `test-race` in order. |
+| `make verify` | Runs `fmt`, `vet`, `lint`, `sec`, `vuln`, `test-race`, and `openapi-check` in order — seven checks, fail-fast. |
 | `make test` | Runs `go test -cover ./...` without race detection — quick smoke check. |
 | `make build` | Builds the binary into `./bin/go-micro-example` with version metadata baked in. |
 | `make run` | Runs the application via `go run ./cmd/.`. Requires Postgres and RabbitMQ. |
@@ -571,8 +572,8 @@ exposed so you can run a single step in isolation:
 | `make clients` | Regenerates Go (`api/client/v1`) and TS (`web/src/api`) clients from the spec. |
 | `make openapi-check` | CI drift gate: regenerates spec + Go client and fails on diff. |
 
-If `make tools` has not been run yet, `lint` and `sec` will fail with
-`command not found`; install the tools first.
+If `make tools` has not been run yet, `lint`, `sec`, and `vuln` will
+fail with `command not found`; install the tools first.
 
 ### Database Migrations
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sksmith/go-micro-example
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/exaring/otelpgx v0.10.0


### PR DESCRIPTION
## Summary

- Add a `make vuln` target (PATH-or-GOBIN fallback, same shape as `lint`/`sec`) and chain it into `make verify` between `sec` and `test-race`. The verify matrix is now fmt -> vet -> lint -> sec -> vuln -> test-race -> openapi-check.
- `make tools` installs `govulncheck@v1.3.0` (pinned per the ticket — the rest of the toolchain is still `@latest`; cleaning that up is its own pass and called out in a comment).
- Bump `go.mod` toolchain directive to `go1.25.10` so the stdlib findings the scanner was reporting against `go1.25.0` clear (mechanical patch bump; the Dockerfiles already build on Go 1.26 and CI's `1.25.x` picks the latest patch automatically).
- Flip [.github/workflows/vuln.yml](.github/workflows/vuln.yml) from soft-fail to hard-fail. The ``continue-on-error: true`` was annotated ``until DEP-001/DEP-002 land`` — both merged. SARIF upload still runs separately so findings continue to surface in the Security tab even when the job is green.
- Update README ``Make targets`` table and the ``make tools`` reminder line.

Ticket: ``plan/SEC-014-makefile-govulncheck.md``.

## Acceptance criteria

- [x] ``make tools`` installs ``govulncheck`` pinned to a specific version (``v1.3.0``), not ``@latest``.
- [x] ``make vuln`` runs ``govulncheck ./...`` using the PATH-or-GOBIN fallback.
- [x] ``make verify`` chains ``vuln`` after ``sec`` and before ``test-race``; findings exit non-zero.
- [x] README ``Make targets`` table updated (entry for ``make vuln`` + revised ``make verify`` description).
- [x] ``make tools && make verify`` exits 0 on master.

## Notes

- The toolchain bump is in-scope here because without it the new hard-gated ``make verify`` would fail on master — SEC-014 isn't useful if landing it breaks the build. Patch-only ``1.25.0 -> 1.25.10``, no API surface change.
- Local ``make verify`` is now green end-to-end.
- Out of scope: pinning gosec/golangci-lint/swag/oapi-codegen off ``@latest`` to match govulncheck. That's a separate hygiene pass — added a one-line comment in ``tools:`` noting it.

## Test plan

- [x] ``make tools`` installs ``govulncheck@v1.3.0``.
- [x] ``make vuln`` succeeds with ``No vulnerabilities found.``
- [x] ``make verify`` exits 0.
- [ ] Reviewer: pull the branch, run ``make tools && make verify``, confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)