### PR TITLE
SEC-009: hard-gate G201/G202 in CI and add SQL-injection spot-checks

### DIFF
--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -29,3 +29,15 @@ jobs:
         with:
           sarif_file: gosec.sarif
           category: gosec
+      # SEC-009: SQL-injection rules (G201 / G202) are Medium severity
+      # and would be filtered out by the High-only gate above. They
+      # need to hard-fail CI on any regression — a Sprintf'd SQL
+      # query is the kind of mistake we cannot afford to ship even
+      # once. Run gosec a second time with -include narrowed to just
+      # those rules and no severity floor so any finding fails the
+      # job. Output is text so the build log shows the offending
+      # line directly; SARIF upload above covers the broader scan.
+      - name: gosec G201/G202 hard-gate
+        uses: securego/gosec@v2.26.1
+        with:
+          args: '-include=G201,G202 -exclude-dir api/client ./...'

--- a/internal/inventory/repository_sqlinjection_test.go
+++ b/internal/inventory/repository_sqlinjection_test.go
@@ -1,0 +1,77 @@
+package inventory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/sksmith/go-micro-example/internal/inventory"
+)
+
+// sqlInjectionPayloads is the SEC-009 spot-check set: classic
+// injection patterns, fed in as user-controlled identifiers. The
+// goal is to fail loudly if any future change pre-renders the
+// payload into the SQL string instead of binding it as a $N
+// parameter. pgxmock's anchored regex on the SQL plus its exact
+// args matcher together guarantee that.
+var sqlInjectionPayloads = []string{
+	`'; DROP TABLE products; --`,
+	`' OR '1'='1`,
+	`sku' UNION SELECT password FROM users --`,
+	`\xC0\x27 OR 1=1 --`,
+}
+
+// TestGetProductSQLInjectionPayloadsAreBoundParameters: the SKU
+// reaches pgx as $1, not as concatenated text.
+func TestGetProductSQLInjectionPayloadsAreBoundParameters(t *testing.T) {
+	for _, payload := range sqlInjectionPayloads {
+		t.Run(payload, func(t *testing.T) {
+			repo, mock := newRepo(t)
+			mock.ExpectQuery(selectProduct).
+				WithArgs(payload).
+				WillReturnRows(pgxmock.NewRows([]string{"sku", "upc", "name"}).
+					AddRow(payload, "upc", "name"))
+
+			if _, err := repo.GetProduct(context.Background(), payload); err != nil {
+				t.Fatalf("GetProduct(%q): %v", payload, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("payload %q reached SQL un-parameterised: %v", payload, err)
+			}
+		})
+	}
+}
+
+// TestGetReservationsSQLInjectionPayloadsAreBoundParameters checks
+// the dynamic-WHERE builder in GetReservations. That code path
+// assembles the SQL at runtime based on which filters are present;
+// the placeholder indices ($3, $4) are computed but the user data
+// is still appended to params, not interpolated. The pgxmock regex
+// for listReservationsBySku expects `sku = \$3` literally — a
+// regression that Sprintf'd the payload into the SQL would change
+// the rendered string and fail the match.
+func TestGetReservationsSQLInjectionPayloadsAreBoundParameters(t *testing.T) {
+	for _, payload := range sqlInjectionPayloads {
+		t.Run(payload, func(t *testing.T) {
+			repo, mock := newRepo(t)
+			mock.ExpectQuery(listReservationsBySku).
+				WithArgs(10, 0, payload).
+				WillReturnRows(pgxmock.NewRows([]string{
+					"id", "request_id", "requester", "sku",
+					"state", "reserved_quantity", "requested_quantity", "created",
+				}))
+
+			_, err := repo.GetReservations(
+				context.Background(),
+				inventory.GetReservationsOptions{Sku: payload},
+				10, 0,
+			)
+			if err != nil {
+				t.Fatalf("GetReservations(%q): %v", payload, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("payload %q reached SQL un-parameterised: %v", payload, err)
+			}
+		})
+	}
+}

--- a/internal/user/repository_sqlinjection_test.go
+++ b/internal/user/repository_sqlinjection_test.go
@@ -1,0 +1,83 @@
+package user_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/sksmith/go-micro-example/internal/user"
+)
+
+// sqlInjectionPayloads is the set of strings exercised against the
+// repository to confirm that user-supplied content always reaches
+// pgx as a bound parameter rather than being interpolated into the
+// SQL string. Each payload mimics a classic attack technique; if any
+// of them ended up in the rendered SQL the pgxmock anchored-regex
+// pattern would fail to match and the test would fail loudly.
+var sqlInjectionPayloads = []string{
+	`'; DROP TABLE users; --`,
+	`' OR '1'='1`,
+	`admin' --`,
+	`\xC0\x27 OR 1=1 --`,
+	`")` + "; DROP TABLE users; --",
+}
+
+// TestGetSQLInjectionPayloadsAreBoundParameters confirms that a
+// hostile username is forwarded to pgx as the $1 parameter and the
+// rendered SQL still contains only the placeholder. The pgxmock
+// regex is anchored on the literal placeholder; if a regression
+// switched the repo to Sprintf the payload into the SQL, the
+// regex would not match and ExpectationsWereMet would fail.
+//
+// This is the SEC-009 spot-check: parameterisation is enforced by
+// pgx's protocol-level prepared statements, but the test gates
+// against a future change that bypasses that protection (e.g. by
+// pre-rendering the SQL).
+func TestGetSQLInjectionPayloadsAreBoundParameters(t *testing.T) {
+	const selectUser = `^SELECT username, password, is_admin, created_at FROM users WHERE username = \$1\s*$`
+
+	for _, payload := range sqlInjectionPayloads {
+		t.Run(payload, func(t *testing.T) {
+			repo, mock := newRepo(t)
+			// The args matcher rejects anything but the exact payload.
+			// The SQL pattern rejects anything but the parameterised
+			// statement. Both must hold for the call to succeed.
+			mock.ExpectQuery(selectUser).
+				WithArgs(payload).
+				WillReturnRows(pgxmock.NewRows([]string{"username", "password", "is_admin", "created_at"}).
+					AddRow(payload, "h", false, zeroTime()))
+
+			_, err := repo.Get(context.Background(), payload)
+			if err != nil {
+				t.Fatalf("Get(%q): %v", payload, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("payload %q reached SQL un-parameterised: %v", payload, err)
+			}
+		})
+	}
+}
+
+// TestDeleteSQLInjectionPayloadsAreBoundParameters covers the DELETE
+// path; the same parameterisation invariant must hold there.
+func TestDeleteSQLInjectionPayloadsAreBoundParameters(t *testing.T) {
+	const deleteUser = `^DELETE FROM users WHERE username = \$1\s*$`
+
+	for _, payload := range sqlInjectionPayloads {
+		t.Run(payload, func(t *testing.T) {
+			repo, mock := newRepo(t)
+			mock.ExpectExec(deleteUser).
+				WithArgs(payload).
+				WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+			if err := repo.Delete(context.Background(), payload); err != nil {
+				t.Fatalf("Delete(%q): %v", payload, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("payload %q reached SQL un-parameterised: %v", payload, err)
+			}
+		})
+	}
+}
+
+func zeroTime() any { return user.User{}.Created }


### PR DESCRIPTION
Closes [plan/complete/SEC-009-sql-injection-audit.md](plan/complete/SEC-009-sql-injection-audit.md).

## Audit summary

Every `tx.Exec`, `tx.Query`, and `tx.QueryRow` call in
[internal/user/repository.go](internal/user/repository.go),
[internal/inventory/repository.go](internal/inventory/repository.go),
and
[internal/platform/idempotency/idempotency.go](internal/platform/idempotency/idempotency.go)
uses pgx `\$N` placeholders for user-supplied data. The only
string concatenation in a query is the `forUpdate` suffix, which
sources from a constant (`""` or `"FOR UPDATE"`) returned by
`persistence.GetQueryOptions` — no user input flows through that
path. Pagination is validated and typed-int through
[internal/platform/httpx/pagination.go](internal/platform/httpx/pagination.go);
limit/offset reach pgx as `\$1, \$2`. `gosec` reports **0** G201/G202
findings.

## Changes

- **`.github/workflows/sec.yml`** — adds a second `gosec` step with `-include=G201,G202` and no severity floor. The existing High-only SARIF upload is unchanged; this just makes a regression in either SQL-injection rule hard-fail CI regardless of their Medium severity rating.
- **`internal/user/repository_sqlinjection_test.go`** + **`internal/inventory/repository_sqlinjection_test.go`** — spot-check tests that feed classic injection payloads (`'; DROP TABLE …`, `' OR '1'='1`, `UNION SELECT password FROM users`, etc.) through `Get`/`Delete`/`GetProduct`/`GetReservations` and assert via pgxmock's anchored SQL regex + exact-args matcher that the payload is bound as a parameter and the rendered SQL is unchanged.

## Deferred follow-up

The audit surfaced a latent bug in `inventory.dbRepo.GetProductionEventByRequestID`: it double-concatenates the `forUpdate` suffix, so the rendered SQL is syntactically invalid when any caller requests `FOR UPDATE`. The only current caller (`inventory/service.go:145`) passes no options, so today both concatenations collapse to empty strings — but it'll break the first time anyone asks for the row lock. Filed locally as SEC-015; not an injection bug, out of scope here.

## Acceptance criteria

- [x] Every SQL string is constant or uses `\$N` placeholders (confirmed by audit + gosec G201/G202 = 0).
- [x] `limit`/`offset` reach the database as `\$N` parameters (confirmed by existing pattern; new spot-check tests pin it down).
- [x] `gosec` rule G201/G202 enabled in CI as a hard gate (new step in `sec.yml`).
- [x] Spot-check tests with `'; DROP TABLE` style payloads against representative endpoints.

## Test plan

- [x] `make verify` — all checks green.
- [x] `gosec -include=G201,G202 ./...` locally — zero findings.
- [x] New spot-check tests pass and would fail if a Sprintf'd query regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)