### PR TITLE
OPS-003: pre-commit hooks + gofumpt enforcement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,10 @@
 version: "2"
+# OPS-003: gofumpt enforced as a formatter so the bundled
+# `golangci-lint fmt` and CI lint both flag drift. The full linter
+# surface stays narrow on purpose; widening it is OPS-010's job.
+formatters:
+  enable:
+    - gofumpt
 linters:
   default: standard
   enable:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# OPS-003: pre-commit hooks. Install with `make precommit-install`
+# (or `pip install pre-commit && pre-commit install`). The hooks here
+# match the checks CI runs in lint.yml + secret.yml; running them
+# locally just catches drift before push.
+repos:
+  - repo: local
+    hooks:
+      - id: gofumpt
+        name: gofumpt
+        description: Apply gofumpt's stricter Go formatting (auto-fixes).
+        entry: gofumpt -l -w
+        language: system
+        types: [go]
+        # api/client/v1 is oapi-codegen output. Reformatting it would
+        # drift from the generator's output and break `make openapi-check`
+        # on the next regen. golangci-lint already auto-skips the file
+        # via its `Code generated ... DO NOT EDIT.` header; gofumpt does
+        # not honour that convention, so it must be excluded by path.
+        exclude: ^api/client/
+        require_serial: false
+
+      - id: golangci-lint
+        name: golangci-lint
+        description: Run golangci-lint with the project's .golangci.yml.
+        entry: golangci-lint run
+        language: system
+        types: [go]
+        pass_filenames: false
+        require_serial: true
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,23 @@ tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install github.com/swaggo/swag/v2/cmd/swag@latest
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	# OPS-003: gofumpt enforces stricter Go formatting; the
+	# pre-commit hook and golangci-lint formatter both depend on it.
+	go install mvdan.cc/gofumpt@latest
 	# govulncheck is pinned (not @latest) so the tool surface that
 	# decides whether `make verify` passes is reproducible across
 	# developer machines and CI. Bump intentionally; the other tools
 	# above are still @latest pending a similar pass.
 	go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+
+# OPS-003: install pre-commit hooks against .pre-commit-config.yaml.
+# Requires the `pre-commit` CLI (brew install pre-commit on macOS,
+# pip install pre-commit elsewhere). The hooks shell out to gofumpt
+# and golangci-lint, both installed by `make tools`.
+.PHONY: precommit-install
+precommit-install:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "pre-commit not found. Install via 'brew install pre-commit' (macOS) or 'pip install pre-commit'."; exit 1; }
+	pre-commit install
 
 .PHONY: openapi clients clients-go clients-ts openapi-check
 openapi:

--- a/README.md
+++ b/README.md
@@ -624,8 +624,9 @@ exposed so you can run a single step in isolation:
 
 | Target | What it does |
 | --- | --- |
-| `make tools` | Installs `golangci-lint`, `gosec`, and `govulncheck` (pinned) into `$(go env GOPATH)/bin`. Run once before `make verify`, and re-run when bumping versions. |
-| `make fmt` | Runs `gofmt -l .` and exits non-zero if any file needs formatting. Does not modify files — fix with `gofmt -w <file>`. |
+| `make tools` | Installs `golangci-lint`, `gosec`, `govulncheck` (pinned), and `gofumpt` into `$(go env GOPATH)/bin`. Run once before `make verify`, and re-run when bumping versions. |
+| `make precommit-install` | Installs the local pre-commit hooks defined in [.pre-commit-config.yaml](.pre-commit-config.yaml) — `gofumpt`, `golangci-lint`, `gitleaks` (OPS-003). Requires the `pre-commit` CLI (`brew install pre-commit` on macOS, `pip install pre-commit` elsewhere) and `$(go env GOPATH)/bin` on `PATH` so the hooks can find `gofumpt` and `golangci-lint` after `make tools`. |
+| `make fmt` | Runs `gofmt -l .` and exits non-zero if any file needs formatting. Does not modify files — fix with `gofmt -w <file>`. The `lint` step additionally enforces gofumpt's stricter rules via golangci-lint's formatter pipeline. |
 | `make vet` | Runs `go vet ./...`. |
 | `make lint` | Runs `golangci-lint run` with the project defaults. |
 | `make sec` | Runs `gosec ./...` (CWE-tagged static analysis). |

--- a/cmd/demo/idempotency_step.go
+++ b/cmd/demo/idempotency_step.go
@@ -50,7 +50,8 @@ func runKafkaDuplicateReplay(ctx context.Context, cfg Config) (string, error) {
 	sharedEventID := uuid.NewString()
 
 	publishCommand := func(requestID string) error {
-		env, err := events.NewEnvelope(sharedEventID, events.TypeRecordProduction, 1, time.Now(),
+		env, err := events.NewEnvelope(
+			sharedEventID, events.TypeRecordProduction, 1, time.Now(),
 			map[string]any{"sku": sku, "requestId": requestID, "quantity": quantity},
 		)
 		if err != nil {

--- a/cmd/demo/kafka_step.go
+++ b/cmd/demo/kafka_step.go
@@ -61,7 +61,8 @@ func runKafkaRoundTrip(ctx context.Context, cfg Config) (string, error) {
 	defer producer.Close()
 
 	const quantity = 7
-	env, err := events.NewEnvelope(uuid.NewString(), events.TypeRecordProduction, 1, time.Now(),
+	env, err := events.NewEnvelope(
+		uuid.NewString(), events.TypeRecordProduction, 1, time.Now(),
 		map[string]any{"sku": sku, "requestId": uuid.NewString(), "quantity": quantity},
 	)
 	if err != nil {

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -160,7 +160,8 @@ func printSummary(w *os.File, results []Result) {
 		if trace == "" {
 			trace = "—"
 		}
-		_, _ = fmt.Fprintf(w, "%-14s %-32s %-6s %10s %s\n",
+		_, _ = fmt.Fprintf(
+			w, "%-14s %-32s %-6s %10s %s\n",
 			r.Capability,
 			truncate(r.Name, 32),
 			r.Status,

--- a/cmd/server/integration_test.go
+++ b/cmd/server/integration_test.go
@@ -23,7 +23,6 @@ import (
 var cfg *config.Config
 
 func TestMain(m *testing.M) {
-
 	log.Info().Msg("configuring logging...")
 
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
@@ -151,7 +150,6 @@ func TestList(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			res, err := http.Get(host() + test.url)
-
 			if err != nil {
 				t.Errorf("unexpected error got=%s", err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -424,7 +424,6 @@ func loadLocalConfigs(filename string, config *Config) error {
 
 func ValueToConfigValue() mapstructure.DecodeHookFunc {
 	return func(f reflect.Value, t reflect.Value) (interface{}, error) {
-
 		if t.Kind() != reflect.Struct {
 			return f.Interface(), nil
 		}
@@ -569,7 +568,6 @@ func getInt(f reflect.Value) (int64, error) {
 }
 
 func loadRemoteConfigs(config *Config) error {
-
 	return nil
 }
 

--- a/internal/app/correlation_integration_test.go
+++ b/internal/app/correlation_integration_test.go
@@ -2,11 +2,12 @@ package app_test
 
 import (
 	"bytes"
-	"github.com/sksmith/go-micro-example/internal/app"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/sksmith/go-micro-example/internal/app"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"

--- a/internal/inventory/dto.go
+++ b/internal/inventory/dto.go
@@ -87,8 +87,7 @@ func (p *CreateProductionEventRequest) Bind(_ *http.Request) error {
 	return nil
 }
 
-type ProductionEventResponse struct {
-} // @name ProductionEventResponse
+type ProductionEventResponse struct{} // @name ProductionEventResponse
 
 func (p *ProductionEventResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil

--- a/internal/inventory/repository.go
+++ b/internal/inventory/repository.go
@@ -81,7 +81,6 @@ func (d *dbRepo) GetProduct(ctx context.Context, sku string, options ...persiste
 	product := Product{}
 	err := tx.QueryRow(ctx, `SELECT sku, upc, name FROM products WHERE sku = $1 `+forUpdate, sku).
 		Scan(&product.Sku, &product.Upc, &product.Name)
-
 	if err != nil {
 		m.Complete(err)
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -101,7 +100,6 @@ func (d *dbRepo) GetProductInventory(ctx context.Context, sku string, options ..
 	productInventory := ProductInventory{}
 	err := tx.QueryRow(ctx, `SELECT p.sku, p.upc, p.name, pi.available FROM products p, product_inventory pi WHERE p.sku = $1 AND p.sku = pi.sku `+forUpdate, sku).
 		Scan(&productInventory.Sku, &productInventory.Upc, &productInventory.Name, &productInventory.Available)
-
 	if err != nil {
 		m.Complete(err)
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -155,7 +153,6 @@ func (d *dbRepo) GetProductionEventByRequestID(ctx context.Context, requestID st
 	pe = ProductionEvent{}
 	err = tx.QueryRow(ctx, `SELECT id, request_id, sku, quantity, created FROM production_events `+forUpdate+` WHERE request_id = $1 `+forUpdate, requestID).
 		Scan(&pe.ID, &pe.RequestID, &pe.Sku, &pe.Quantity, &pe.Created)
-
 	if err != nil {
 		m.Complete(err)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/inventory/service.go
+++ b/internal/inventory/service.go
@@ -45,8 +45,10 @@ func (s *service) SetEventEmitter(e EventEmitter) {
 	s.emitter = e
 }
 
-type InventorySubID string
-type ReservationsSubID string
+type (
+	InventorySubID    string
+	ReservationsSubID string
+)
 
 type GetReservationsOptions struct {
 	Sku   string

--- a/internal/inventory/service_test.go
+++ b/internal/inventory/service_test.go
@@ -2,13 +2,13 @@ package inventory_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
 	"time"
 
-	"errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/sksmith/go-micro-example/internal/inventory"
 	"github.com/sksmith/go-micro-example/internal/platform/cache"

--- a/internal/inventory/transport_http.go
+++ b/internal/inventory/transport_http.go
@@ -205,7 +205,6 @@ func (a *InventoryApi) ProductCtx(next http.Handler) http.Handler {
 		}
 
 		product, err = a.service.GetProduct(r.Context(), sku)
-
 		if err != nil {
 			if errors.Is(err, persistence.ErrNotFound) {
 				httpx.Render(w, r, httpx.NotFoundProblem())
@@ -275,7 +274,6 @@ func (a *InventoryApi) GetProductInventory(w http.ResponseWriter, r *http.Reques
 	product := r.Context().Value(CtxKeyProduct).(Product)
 
 	res, err := a.service.GetProductInventory(r.Context(), product.Sku)
-
 	if err != nil {
 		if errors.Is(err, persistence.ErrNotFound) {
 			httpx.Render(w, r, httpx.NotFoundProblem())

--- a/internal/inventory/transport_http_reservation.go
+++ b/internal/inventory/transport_http_reservation.go
@@ -147,7 +147,6 @@ func (a *ReservationApi) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := a.service.Reserve(r.Context(), *data.ReservationRequest)
-
 	if err != nil {
 		switch {
 		case errors.Is(err, persistence.ErrNotFound):
@@ -188,7 +187,6 @@ func (a *ReservationApi) ReservationCtx(next http.Handler) http.Handler {
 		}
 
 		reservation, err := a.service.GetReservation(r.Context(), ID)
-
 		if err != nil {
 			if errors.Is(err, persistence.ErrNotFound) {
 				httpx.Render(w, r, httpx.NotFoundProblem())
@@ -233,7 +231,6 @@ func (a *ReservationApi) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := a.service.GetReservations(r.Context(), GetReservationsOptions{Sku: sku, State: state}, p.Limit, p.Offset)
-
 	if err != nil {
 		if errors.Is(err, persistence.ErrNotFound) {
 			httpx.Render(w, r, httpx.NotFoundProblem())

--- a/internal/inventory/transport_http_reservation_test.go
+++ b/internal/inventory/transport_http_reservation_test.go
@@ -389,8 +389,10 @@ func TestReservationList(t *testing.T) {
 }
 
 func createReservationRequest(requestID, requester, sku string, quantity int64) *inventory.ReservationRequestDto {
-	return &inventory.ReservationRequestDto{ReservationRequest: &inventory.ReservationRequest{
-		Sku: sku, RequestID: requestID, Requester: requester, Quantity: quantity},
+	return &inventory.ReservationRequestDto{
+		ReservationRequest: &inventory.ReservationRequest{
+			Sku: sku, RequestID: requestID, Requester: requester, Quantity: quantity,
+		},
 	}
 }
 

--- a/internal/platform/idempotency/idempotency.go
+++ b/internal/platform/idempotency/idempotency.go
@@ -95,7 +95,8 @@ func (a *Applier) Apply(ctx context.Context, eventID string, fn func(ctx context
 		return errors.New("idempotency: eventID is required")
 	}
 
-	tag, err := a.pool.Exec(ctx,
+	tag, err := a.pool.Exec(
+		ctx,
 		"INSERT INTO processed_events (event_id, consumer_group) VALUES ($1, $2) ON CONFLICT DO NOTHING",
 		eventID, a.consumerGroup,
 	)
@@ -114,7 +115,8 @@ func (a *Applier) Apply(ctx context.Context, eventID string, fn func(ctx context
 		// handler error — the next delivery will see the row and
 		// skip, but the consumer's bounded-retry/DLT logic will
 		// route it correctly.
-		if _, delErr := a.pool.Exec(ctx,
+		if _, delErr := a.pool.Exec(
+			ctx,
 			"DELETE FROM processed_events WHERE event_id = $1 AND consumer_group = $2",
 			eventID, a.consumerGroup,
 		); delErr != nil {
@@ -138,7 +140,8 @@ type CleanupResult struct {
 // retention window. Returns the number of rows removed.
 func (a *Applier) CleanupOnce(ctx context.Context, window time.Duration) (CleanupResult, error) {
 	cutoff := time.Now().Add(-window)
-	tag, err := a.pool.Exec(ctx,
+	tag, err := a.pool.Exec(
+		ctx,
 		"DELETE FROM processed_events WHERE processed_at < $1",
 		cutoff,
 	)

--- a/internal/platform/observability/tracing.go
+++ b/internal/platform/observability/tracing.go
@@ -70,7 +70,8 @@ func InitTracing(ctx context.Context, cfg TracingConfig) (ShutdownFunc, error) {
 		return func(context.Context) error { return nil }, nil
 	}
 
-	res, err := resource.New(ctx,
+	res, err := resource.New(
+		ctx,
 		resource.WithFromEnv(),
 		resource.WithProcess(),
 		resource.WithTelemetrySDK(),

--- a/internal/platform/persistence/metrics.go
+++ b/internal/platform/persistence/metrics.go
@@ -1,8 +1,9 @@
 package persistence
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (

--- a/internal/platform/persistence/postgres.go
+++ b/internal/platform/persistence/postgres.go
@@ -84,7 +84,6 @@ func addOptionsToConnStr(connStr string, options ...configOption) string {
 }
 
 func ConnectDb(ctx context.Context, cfg *config.Config) (*pgxpool.Pool, error) {
-
 	log.Info().Str("host", cfg.Db.Host.Value).Str("name", cfg.Db.Name.Value).Msg("connecting to the database...")
 	var err error
 

--- a/internal/platform/ratelimit/limiter.go
+++ b/internal/platform/ratelimit/limiter.go
@@ -144,7 +144,8 @@ func (l *Limiter) Allow(ctx context.Context, key, scope string) (Decision, error
 		ttlSeconds = 60
 	}
 
-	res, err := luaScript.Run(ctx, l.client, []string{key},
+	res, err := luaScript.Run(
+		ctx, l.client, []string{key},
 		l.cfg.Rate, l.cfg.Burst, 1, nowMs, ttlSeconds,
 	).Result()
 	if err != nil {

--- a/internal/user/bootstrap.go
+++ b/internal/user/bootstrap.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-
 	"errors"
+
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
 	"golang.org/x/crypto/bcrypt"

--- a/internal/user/repository.go
+++ b/internal/user/repository.go
@@ -98,7 +98,6 @@ func (r *dbRepo) Delete(ctx context.Context, username string, txs ...persistence
 	tx := persistence.GetUpdateOptions(r.conn, txs...)
 
 	_, err := tx.Exec(ctx, `DELETE FROM users WHERE username = $1`, username)
-
 	if err != nil {
 		m.Complete(err)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/user/transport_http.go
+++ b/internal/user/transport_http.go
@@ -54,7 +54,6 @@ func (a *UserApi) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err := a.service.Create(r.Context(), *data.CreateUserRequest)
-
 	if err != nil {
 		if errors.Is(err, ErrInvalidInput) {
 			httpx.Render(w, r, httpx.BadRequestProblem(err))


### PR DESCRIPTION
## Summary

Ticket: [OPS-003](plan/OPS-003-sast-pre-commit.md) — local lint and pre-commit hygiene so SEC/DEP work doesn't get undone by drift between contributors.

CI already runs `golangci-lint` and `gitleaks` (lint.yml, secret.yml from OPS-001), so the gap was the *local* side: drift you only notice when CI yells. This PR closes that loop.

### Changes

- **`.pre-commit-config.yaml`** (new) — three hooks:
  - `gofumpt` (local) — applies stricter formatting, auto-fixes.
  - `golangci-lint` (local) — runs the project's `.golangci.yml`.
  - `gitleaks` v8.30.1 (upstream) — secret detection.
  - `gofumpt` excludes `^api/client/` because `oapi-codegen` output isn't gofumpt-clean and reformatting it would drift from the generator and break `make openapi-check` on the next regen. `golangci-lint` already honours the `Code generated ... DO NOT EDIT.` header automatically; `gofumpt` doesn't.

- **`.golangci.yml`** — enables `gofumpt` as a formatter so `golangci-lint run` (used by `make lint` and CI) fails on drift the same way pre-commit does.

- **Makefile** — adds `gofumpt` to `make tools` and a `make precommit-install` target that wraps `pre-commit install` with a friendly error if the CLI isn't installed.

- **README** — adds `make precommit-install` to the Make-targets table, notes the `$(go env GOPATH)/bin` PATH requirement that the `language: system` hooks rely on, and refreshes the `make tools` row.

- **21 files reformatted by `gofumpt -w .`** — pure-cosmetic blank-line and parenthesis-layout cleanup, no logic changes, so the new lint surface starts green. Net `+51 / -33` lines across `cmd/`, `config/`, and `internal/`.

### Linter surface

The ticket lists `errcheck`, `gosec`, `govet`, `ineffassign`, `revive`, `staticcheck`, `unused`, `bodyclose`, `gocritic`, `misspell` as the minimum surface. The current `.golangci.yml` uses `default: standard` (errcheck, govet, ineffassign, staticcheck, unused) + errorlint + errname. **Expansion to revive/bodyclose/gocritic/misspell is deferred to [OPS-010](plan/OPS-010-full-linter-surface.md)**, which exists specifically for that work, and per OPS-003's own "be conservative on first introduction" guidance.

`gosec` already runs separately via `make sec` and CI's `sec.yml` workflow.

## Acceptance criteria

- [x] `.golangci.yml` committed; CI runs `golangci-lint run`. (already wired in `lint.yml`)
- [x] `gofumpt` enforced — via golangci-lint's formatter pipeline.
- [x] `pre-commit` hooks run `gofumpt`, `golangci-lint`, `gitleaks`.
- [x] README documents the hook install (`make precommit-install`).
- [ ] Full linter expansion to `revive`/`bodyclose`/`gocritic`/`misspell` — **deferred to OPS-010**.

## Verification

```
$ make verify
==> verify OK

$ make precommit-install   # then `pre-commit run --all-files`
gofumpt..................................................................Passed
golangci-lint............................................................Passed
Detect hardcoded secrets.................................................Passed
```

## Test plan

- [ ] CI is green (lint, sec, secret workflows).
- [ ] `make precommit-install` installs and the three hooks fire on a Go-file commit.
- [ ] An intentional gofumpt drift is rejected by `make lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)