### PR TITLE
OPS-009: rewrite WebSocket subscribe tests without an in-process WS round-trip

### DIFF
--- a/internal/inventory/export_test.go
+++ b/internal/inventory/export_test.go
@@ -1,0 +1,20 @@
+package inventory
+
+// export_test.go re-exports a handful of package-private symbols
+// solely for the inventory_test external test package. None of these
+// names exist outside `go test`. The pattern keeps the production
+// surface narrow while still letting black-box tests drive the
+// streaming helpers extracted for OPS-009.
+
+// TextWriterForTest is the public alias of the textWriter interface.
+type TextWriterForTest = textWriter
+
+// StreamInventoryToClientForTest exposes streamInventoryToClient.
+func StreamInventoryToClientForTest(svc InventoryService, w textWriter) {
+	streamInventoryToClient(svc, w)
+}
+
+// StreamReservationsToClientForTest exposes streamReservationsToClient.
+func StreamReservationsToClientForTest(svc ReservationService, w textWriter) {
+	streamReservationsToClient(svc, w)
+}

--- a/internal/inventory/transport_http.go
+++ b/internal/inventory/transport_http.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/gobwas/ws"
-	"github.com/gobwas/ws/wsutil"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/internal/catalog"
 	"github.com/sksmith/go-micro-example/internal/platform/httpx"
@@ -105,30 +104,37 @@ func (a *InventoryApi) Subscribe(w http.ResponseWriter, r *http.Request) {
 	}
 	go func() {
 		defer conn.Close()
-
-		ch := make(chan ProductInventory, 1)
-
-		id := a.service.SubscribeInventory(ch)
-		defer func() {
-			a.service.UnsubscribeInventory(id)
-		}()
-
-		for inv := range ch {
-			resp := &ProductResponse{ProductInventory: inv}
-			body, err := json.Marshal(resp)
-			if err != nil {
-				log.Error().Err(err).Interface("clientId", id).Msg("failed to marshal product response")
-				continue
-			}
-
-			log.Debug().Interface("clientId", id).Interface("productResponse", resp).Msg("sending inventory update to client")
-			err = wsutil.WriteServerText(conn, body)
-			if err != nil {
-				log.Error().Err(err).Interface("clientId", id).Msg("failed to write server message, disconnecting client")
-				return
-			}
-		}
+		streamInventoryToClient(a.service, wsTextWriter{conn: conn})
 	}()
+}
+
+// streamInventoryToClient is the WS-independent half of Subscribe: it
+// subscribes via the service, marshals every ProductInventory off the
+// channel into a ProductResponse JSON frame, and writes each frame
+// through writer until the channel closes or a write fails. Pulled
+// out of the handler so it can be unit-tested against a recording
+// writer (OPS-009) — the pre-refactor in-process WS round-trip flaked
+// under the Go 1.24 scheduler on Linux/macOS GitHub runners and the
+// test ended up t.Skip'd.
+func streamInventoryToClient(svc InventoryService, writer textWriter) {
+	ch := make(chan ProductInventory, 1)
+	id := svc.SubscribeInventory(ch)
+	defer svc.UnsubscribeInventory(id)
+
+	for inv := range ch {
+		resp := &ProductResponse{ProductInventory: inv}
+		body, err := json.Marshal(resp)
+		if err != nil {
+			log.Error().Err(err).Interface("clientId", id).Msg("failed to marshal product response")
+			continue
+		}
+
+		log.Debug().Interface("clientId", id).Interface("productResponse", resp).Msg("sending inventory update to client")
+		if err := writer.WriteText(body); err != nil {
+			log.Error().Err(err).Interface("clientId", id).Msg("failed to write server message, disconnecting client")
+			return
+		}
+	}
 }
 
 // List returns a page of product inventory.

--- a/internal/inventory/transport_http_reservation.go
+++ b/internal/inventory/transport_http_reservation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 	"github.com/gobwas/ws"
-	"github.com/gobwas/ws/wsutil"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/internal/platform/httpx"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
@@ -77,31 +76,32 @@ func (a *ReservationApi) Subscribe(w http.ResponseWriter, r *http.Request) {
 	}
 	go func() {
 		defer conn.Close()
-
-		ch := make(chan Reservation, 1)
-
-		id := a.service.SubscribeReservations(ch)
-		defer func() {
-			a.service.UnsubscribeReservations(id)
-		}()
-
-		for res := range ch {
-			resp := &ReservationResponse{Reservation: res}
-
-			body, err := json.Marshal(resp)
-			if err != nil {
-				log.Error().Err(err).Interface("clientId", id).Msg("failed to marshal reservation response")
-				continue
-			}
-
-			log.Debug().Interface("clientId", id).Interface("reservationResponse", resp).Msg("sending reservation update to client")
-			err = wsutil.WriteServerText(conn, body)
-			if err != nil {
-				log.Error().Err(err).Interface("clientId", id).Msg("failed to write server message, disconnecting client")
-				return
-			}
-		}
+		streamReservationsToClient(a.service, wsTextWriter{conn: conn})
 	}()
+}
+
+// streamReservationsToClient mirrors streamInventoryToClient on the
+// reservation side. Both helpers exist for the same reason — see the
+// comment on streamInventoryToClient for the OPS-009 context.
+func streamReservationsToClient(svc ReservationService, writer textWriter) {
+	ch := make(chan Reservation, 1)
+	id := svc.SubscribeReservations(ch)
+	defer svc.UnsubscribeReservations(id)
+
+	for res := range ch {
+		resp := &ReservationResponse{Reservation: res}
+		body, err := json.Marshal(resp)
+		if err != nil {
+			log.Error().Err(err).Interface("clientId", id).Msg("failed to marshal reservation response")
+			continue
+		}
+
+		log.Debug().Interface("clientId", id).Interface("reservationResponse", resp).Msg("sending reservation update to client")
+		if err := writer.WriteText(body); err != nil {
+			log.Error().Err(err).Interface("clientId", id).Msg("failed to write server message, disconnecting client")
+			return
+		}
+	}
 }
 
 // Get returns a single reservation by ID.

--- a/internal/inventory/transport_http_reservation_test.go
+++ b/internal/inventory/transport_http_reservation_test.go
@@ -2,86 +2,108 @@ package inventory_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/gobwas/ws"
 	"github.com/sksmith/go-micro-example/internal/inventory"
 	"github.com/sksmith/go-micro-example/internal/platform/httpx"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
 	"github.com/sksmith/go-micro-example/internal/testutil"
 )
 
-func TestReservationSubscribe(t *testing.T) {
-	// See TestInventorySubscribe — same flake, same skip reason.
-	t.Skip("WS subscribe test is flaky on Linux/macOS under Go 1.24 — see OPS-009")
+// TestReservationSubscribe_StreamsThenUnsubscribes is the OPS-009
+// replacement for the prior in-process WS round-trip. Same shape as
+// TestInventorySubscribe_StreamsThenUnsubscribes; see that test for
+// the rationale.
+func TestReservationSubscribe_StreamsThenUnsubscribes(t *testing.T) {
 	mockSvc := inventory.NewMockReservationService()
+	expectedSubID := inventory.ReservationsSubID("subid1")
+	items := getTestReservations()
 
-	subscribed := make(chan struct{}, 1)
-	unsubscribed := make(chan struct{}, 1)
-	releaseSubscribe := make(chan struct{})
-	expectedSubId := inventory.ReservationsSubID("subid1")
-
-	mockSvc.SubscribeReservationsFunc = func(ch chan<- inventory.Reservation) (id inventory.ReservationsSubID) {
-		subscribed <- struct{}{}
+	mockSvc.SubscribeReservationsFunc = func(ch chan<- inventory.Reservation) inventory.ReservationsSubID {
 		go func() {
-			res := getTestReservations()
-			for i := 0; i < 3; i++ {
-				ch <- res[i]
+			for _, item := range items {
+				ch <- item
 			}
-			// Hold the channel open until the test has read all
-			// items off the websocket; otherwise the handler's
-			// defer conn.Close() can race ahead and the client
-			// sees EOF mid-read.
-			<-releaseSubscribe
 			close(ch)
 		}()
-
-		return expectedSubId
+		return expectedSubID
 	}
 
+	var (
+		unsubMu sync.Mutex
+		unsubID inventory.ReservationsSubID
+	)
 	mockSvc.UnsubscribeReservationsFunc = func(id inventory.ReservationsSubID) {
-		unsubscribed <- struct{}{}
+		unsubMu.Lock()
+		defer unsubMu.Unlock()
+		unsubID = id
 	}
 
-	resApi := inventory.NewReservationApi(mockSvc)
-	r := chi.NewRouter()
-	resApi.ConfigureRouter(r)
-	ts := httptest.NewServer(r)
-	defer ts.Close()
+	w := &recordingTextWriter{}
+	inventory.StreamReservationsToClientForTest(mockSvc, w)
 
-	url := strings.Replace(ts.URL, "http", "ws", 1) + "/subscribe"
-
-	conn, _, _, err := ws.DefaultDialer.Dial(context.Background(), url)
-	if err != nil {
-		t.Fatal(err)
+	frames := w.snapshot()
+	if len(frames) != len(items) {
+		t.Fatalf("frames written = %d, want %d", len(frames), len(items))
+	}
+	for i, frame := range frames {
+		var got inventory.ReservationResponse
+		if err := json.Unmarshal(frame, &got); err != nil {
+			t.Fatalf("frame[%d] not JSON: %v\nbody=%s", i, err, frame)
+		}
+		if !reflect.DeepEqual(got.Reservation, items[i]) {
+			t.Errorf("frame[%d] = %+v, want %+v", i, got.Reservation, items[i])
+		}
 	}
 
-	curRes := getTestReservations()
-	for i := 0; i < 3; i++ {
-		got := &inventory.Reservation{}
-		testutil.ReadWs(conn, got, t)
-
-		reflect.DeepEqual(got, curRes[i])
+	unsubMu.Lock()
+	defer unsubMu.Unlock()
+	if unsubID != expectedSubID {
+		t.Errorf("Unsubscribe got id=%q, want %q", unsubID, expectedSubID)
 	}
-	close(releaseSubscribe)
+}
 
-	select {
-	case <-subscribed:
-	case <-time.After(time.Second):
-		t.Errorf("subscribe never called")
+// TestReservationSubscribe_StopsOnWriteError mirrors the
+// disconnect-branch test on the inventory side.
+func TestReservationSubscribe_StopsOnWriteError(t *testing.T) {
+	mockSvc := inventory.NewMockReservationService()
+	expectedSubID := inventory.ReservationsSubID("subid-disconnect")
+	items := getTestReservations()
+
+	mockSvc.SubscribeReservationsFunc = func(ch chan<- inventory.Reservation) inventory.ReservationsSubID {
+		go func() {
+			defer close(ch)
+			for _, item := range items {
+				ch <- item
+			}
+		}()
+		return expectedSubID
 	}
 
-	select {
-	case <-unsubscribed:
-	case <-time.After(time.Second):
-		t.Errorf("unsubscribe never called")
+	var unsubCalled bool
+	mockSvc.UnsubscribeReservationsFunc = func(id inventory.ReservationsSubID) {
+		if id != expectedSubID {
+			t.Errorf("Unsubscribe id=%q want %q", id, expectedSubID)
+		}
+		unsubCalled = true
+	}
+
+	w := &recordingTextWriter{err: errors.New("client disconnected")}
+	inventory.StreamReservationsToClientForTest(mockSvc, w)
+
+	if got := w.snapshot(); len(got) != 0 {
+		t.Errorf("write-error path should never record a frame, got %d", len(got))
+	}
+	if !unsubCalled {
+		t.Error("Unsubscribe must run on write-error exit (defer)")
 	}
 }
 

--- a/internal/inventory/transport_http_test.go
+++ b/internal/inventory/transport_http_test.go
@@ -2,16 +2,15 @@ package inventory_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
+	"sync"
 	"testing"
-	"time"
 
-	"github.com/gobwas/ws"
 	"github.com/sksmith/go-micro-example/internal/catalog"
 	"github.com/sksmith/go-micro-example/internal/inventory"
 	"github.com/sksmith/go-micro-example/internal/platform/httpx"
@@ -21,76 +20,133 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func TestInventorySubscribe(t *testing.T) {
-	// Flaky under Go 1.24 on Linux/macOS CI runners: the handler reports
-	// 3 frames written via wsutil.WriteServerText but the dialer's
-	// ReadHeader times out waiting for any bytes. Passes locally and on
-	// Windows. Tracked in OPS-007 — re-enable once the WS test harness
-	// is rewritten without an in-process httptest WS round-trip.
-	t.Skip("WS subscribe test is flaky on Linux/macOS under Go 1.24 — see OPS-009")
+// recordingTextWriter is the test-side implementation of the
+// (unexported) textWriter interface in the inventory package. It
+// captures every frame written so tests can assert payload shape
+// and order without an in-process WS dialer (OPS-009).
+//
+// Setting err non-nil makes WriteText fail without recording — used
+// to drive the "stop streaming on write error" branch of the
+// handler.
+type recordingTextWriter struct {
+	mu     sync.Mutex
+	frames [][]byte
+	err    error
+}
+
+func (r *recordingTextWriter) WriteText(b []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.frames = append(r.frames, append([]byte(nil), b...))
+	return nil
+}
+
+func (r *recordingTextWriter) snapshot() [][]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]byte, len(r.frames))
+	for i, f := range r.frames {
+		out[i] = append([]byte(nil), f...)
+	}
+	return out
+}
+
+// TestInventorySubscribe_StreamsThenUnsubscribes is the OPS-009
+// replacement for the old in-process WS round-trip test. It exercises
+// the same contract — subscribe to the service, marshal each inventory
+// item as a ProductResponse-shaped JSON frame, write it, unsubscribe
+// when the channel closes — but drives the loop through the textWriter
+// seam instead of dialing a real websocket. Deterministic on every
+// platform; no time.Sleep, no released-signal channel.
+func TestInventorySubscribe_StreamsThenUnsubscribes(t *testing.T) {
 	mockSvc := inventory.NewMockInventoryService()
+	expectedSubID := inventory.InventorySubID("subid1")
+	items := getTestProductInventory()
 
-	subscribed := make(chan struct{}, 1)
-	unsubscribed := make(chan struct{}, 1)
-	releaseSubscribe := make(chan struct{})
-	expectedSubId := inventory.InventorySubID("subid1")
-
-	mockSvc.SubscribeInventoryFunc = func(ch chan<- inventory.ProductInventory) (id inventory.InventorySubID) {
-		subscribed <- struct{}{}
+	mockSvc.SubscribeInventoryFunc = func(ch chan<- inventory.ProductInventory) inventory.InventorySubID {
+		// Push all three items then close ch. The receiving streamer
+		// will drain in order and return on close — deterministic
+		// without any external synchronisation.
 		go func() {
-			inv := getTestProductInventory()
-			for i := 0; i < 3; i++ {
-				ch <- inv[i]
+			for _, item := range items {
+				ch <- item
 			}
-			// Hold the channel open until the test has read all
-			// items off the websocket; otherwise the handler's
-			// defer conn.Close() can race ahead and the client
-			// sees EOF mid-read.
-			<-releaseSubscribe
 			close(ch)
 		}()
-
-		return expectedSubId
+		return expectedSubID
 	}
 
+	var (
+		unsubMu sync.Mutex
+		unsubID inventory.InventorySubID
+	)
 	mockSvc.UnsubscribeInventoryFunc = func(id inventory.InventorySubID) {
-		unsubscribed <- struct{}{}
+		unsubMu.Lock()
+		defer unsubMu.Unlock()
+		unsubID = id
 	}
 
-	invApi := inventory.NewInventoryApi(mockSvc)
-	r := chi.NewRouter()
-	invApi.ConfigureRouter(r)
-	ts := httptest.NewServer(r)
-	defer ts.Close()
+	w := &recordingTextWriter{}
+	inventory.StreamInventoryToClientForTest(mockSvc, w)
 
-	url := strings.Replace(ts.URL, "http", "ws", 1) + "/subscribe"
-
-	conn, _, _, err := ws.DefaultDialer.Dial(context.Background(), url)
-	if err != nil {
-		t.Fatal(err)
+	frames := w.snapshot()
+	if len(frames) != len(items) {
+		t.Fatalf("frames written = %d, want %d", len(frames), len(items))
 	}
-
-	curInv := getTestProductInventory()
-	for i := 0; i < 3; i++ {
-		got := &inventory.ProductInventory{}
-		testutil.ReadWs(conn, got, t)
-
-		if got.Name != curInv[i].Name {
-			t.Errorf("unexpected ws response[%d] got=[%s] want=[%s]", i, got.Name, curInv[i].Name)
+	for i, frame := range frames {
+		var got inventory.ProductResponse
+		if err := json.Unmarshal(frame, &got); err != nil {
+			t.Fatalf("frame[%d] not JSON: %v\nbody=%s", i, err, frame)
+		}
+		if got.Name != items[i].Name {
+			t.Errorf("frame[%d].Name = %q, want %q", i, got.Name, items[i].Name)
 		}
 	}
-	close(releaseSubscribe)
 
-	select {
-	case <-subscribed:
-	case <-time.After(time.Second):
-		t.Errorf("subscribe never called")
+	unsubMu.Lock()
+	defer unsubMu.Unlock()
+	if unsubID != expectedSubID {
+		t.Errorf("Unsubscribe got id=%q, want %q", unsubID, expectedSubID)
+	}
+}
+
+// TestInventorySubscribe_StopsOnWriteError pins the disconnect branch:
+// a failing WriteText must short-circuit the streaming loop *and*
+// still fire Unsubscribe (the defer in the handler).
+func TestInventorySubscribe_StopsOnWriteError(t *testing.T) {
+	mockSvc := inventory.NewMockInventoryService()
+	expectedSubID := inventory.InventorySubID("subid-disconnect")
+	items := getTestProductInventory()
+
+	mockSvc.SubscribeInventoryFunc = func(ch chan<- inventory.ProductInventory) inventory.InventorySubID {
+		go func() {
+			defer close(ch)
+			for _, item := range items {
+				ch <- item
+			}
+		}()
+		return expectedSubID
 	}
 
-	select {
-	case <-unsubscribed:
-	case <-time.After(time.Second):
-		t.Errorf("unsubscribe never called")
+	var unsubCalled bool
+	mockSvc.UnsubscribeInventoryFunc = func(id inventory.InventorySubID) {
+		if id != expectedSubID {
+			t.Errorf("Unsubscribe id=%q want %q", id, expectedSubID)
+		}
+		unsubCalled = true
+	}
+
+	w := &recordingTextWriter{err: errors.New("client disconnected")}
+	inventory.StreamInventoryToClientForTest(mockSvc, w)
+
+	if got := w.snapshot(); len(got) != 0 {
+		t.Errorf("write-error path should never record a frame, got %d", len(got))
+	}
+	if !unsubCalled {
+		t.Error("Unsubscribe must run on write-error exit (defer)")
 	}
 }
 

--- a/internal/inventory/transport_ws_writer.go
+++ b/internal/inventory/transport_ws_writer.go
@@ -1,0 +1,26 @@
+package inventory
+
+import (
+	"net"
+
+	"github.com/gobwas/ws/wsutil"
+)
+
+// textWriter is the surface the Subscribe streaming helpers
+// (streamInventoryToClient, streamReservationsToClient) call into to
+// emit a single WS text frame. Extracted as an interface so unit
+// tests can drive the streaming logic against an in-memory recorder
+// without an in-process WS dialer — the OPS-009 root cause was that
+// the prior tests went through ws.Dialer + httptest.NewServer and
+// flaked under the Go 1.24 scheduler on Linux/macOS runners.
+type textWriter interface {
+	WriteText(b []byte) error
+}
+
+// wsTextWriter is the production implementation: it forwards each
+// frame through gobwas/ws/wsutil onto a real net.Conn.
+type wsTextWriter struct{ conn net.Conn }
+
+func (w wsTextWriter) WriteText(b []byte) error {
+	return wsutil.WriteServerText(w.conn, b)
+}

--- a/internal/testutil/http_util.go
+++ b/internal/testutil/http_util.go
@@ -4,11 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"net"
 	"net/http"
 	"testing"
-
-	"github.com/gobwas/ws/wsutil"
 )
 
 func Unmarshal(res *http.Response, v interface{}, t *testing.T) {
@@ -56,16 +53,4 @@ func SendRequest(method, url string, request interface{}, t *testing.T, op ...Re
 	}
 
 	return res
-}
-
-func ReadWs(conn net.Conn, v interface{}, t *testing.T) {
-	msg, _, err := wsutil.ReadServerData(conn)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = json.Unmarshal(msg, v)
-	if err != nil {
-		t.Fatal(err)
-	}
 }


### PR DESCRIPTION
## Summary

Ticket: [OPS-009](plan/OPS-009-ws-subscribe-test-harness.md) — restore the two `t.Skip`'d Subscribe tests that DEP-001 had to disable when the Go 1.17 → 1.24 toolchain bump made them hang for the 10-minute package timeout on Linux/macOS runners.

The flake was an in-process WS round-trip: the handler reported all three frames flushed via `wsutil.WriteServerText` but the dialer parked in `ws.ReadHeader` waiting for two bytes that never arrived. Windows runners passed. A `releaseSubscribe` signal channel masked the race locally but didn't survive CI; the second push gave up and `t.Skip`'d both tests so DEP-001 could merge.

This PR takes the ticket's recommended path: extract the WS-independent half of each handler into a unit-testable helper that takes a `textWriter` interface. No more `httptest.NewServer`, no more `ws.Dialer`, no more kernel TCP buffer or Go-scheduler-dependent goroutine handoff. Deterministic by construction on every platform.

## Extraction

The streaming half of each Subscribe handler — subscribe to the service, marshal each item into a `*Response` JSON frame, write each frame, unsubscribe on close — is pulled into:

- `streamInventoryToClient(svc, writer)`
- `streamReservationsToClient(svc, writer)`

`textWriter` (one-method interface, `WriteText(b []byte) error`) is in [`transport_ws_writer.go`](internal/inventory/transport_ws_writer.go). The production adapter `wsTextWriter` forwards to `wsutil.WriteServerText`. The Subscribe handlers are now four lines that upgrade WS, spawn the goroutine, and call the helper with the adapter — same JSON shape, same Subscribe → write loop → Unsubscribe ordering, same disconnect-on-write-error semantics.

## Tests

Four unit tests replace the two `t.Skip`'d ones, via the standard `export_test.go` pattern for giving an external `_test` package access to package-private symbols:

| Test | What it pins |
| --- | --- |
| `TestInventorySubscribe_StreamsThenUnsubscribes` | Three items pushed → three JSON frames recorded in order, `UnsubscribeInventory` called with the producer's sub ID. |
| `TestInventorySubscribe_StopsOnWriteError` | Writer returns an error on the first frame → loop short-circuits without recording, defer'd `UnsubscribeInventory` still runs. |
| `TestReservationSubscribe_StreamsThenUnsubscribes` | Same shape, reservation side. |
| `TestReservationSubscribe_StopsOnWriteError` | Same. |

All four run in ~1 ms. No `time.Sleep`, no `releaseSubscribe` signal channel, no `httptest.NewServer`, no `ws.DefaultDialer.Dial`.

## Cleanup

`testutil.ReadWs` was only called by the now-removed dialer-based tests. Deleted.

## Acceptance criteria

- [x] `t.Skip` removed from both tests (replaced wholesale with the unit-test variants).
- [x] The new tests are platform-independent (no kernel TCP buffer, no Go-scheduler-dependent goroutine handoff). They pass on all three GitHub-hosted OSes by construction — there's no platform-specific code path left.
- [x] No `time.Sleep`-based synchronisation.

## Verification

```
$ make verify
==> verify OK

$ go test ./internal/inventory -run TestInventorySubscribe -v
--- PASS: TestInventorySubscribe_StreamsThenUnsubscribes (0.00s)
--- PASS: TestInventorySubscribe_StopsOnWriteError (0.00s)

$ go test ./internal/inventory -run TestReservationSubscribe -v
--- PASS: TestReservationSubscribe_StreamsThenUnsubscribes (0.00s)
--- PASS: TestReservationSubscribe_StopsOnWriteError (0.00s)
```

## Test plan

- [ ] CI green on all three platforms (Linux, macOS, Windows) — three consecutive runs to satisfy the ticket's anti-flake bar.
- [ ] Manual: the handler still works against a real WS client (the only changed code path is the goroutine body, which compiles against the same `wsutil.WriteServerText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)