### PR TITLE
OPS-010: re-enable full linter surface, fix all findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,10 @@
 version: "2"
-# OPS-003: gofumpt enforced as a formatter so the bundled
-# `golangci-lint fmt` and CI lint both flag drift. The full linter
-# surface stays narrow on purpose; widening it is OPS-010's job.
+# OPS-003: gofumpt enforced as a formatter so `golangci-lint fmt`
+# and CI lint both flag drift.
+# OPS-010: full linter surface — no staticcheck check filters, no
+# errcheck function excludes. Every finding is fixed in code; the
+# only suppressions live in `linters.settings.<name>` blocks below
+# with a comment explaining why.
 formatters:
   enable:
     - gofumpt
@@ -15,19 +18,3 @@ linters:
     # ERR-001: enforce ErrXxx for sentinel error vars and
     # XxxError for error types.
     - errname
-  settings:
-    staticcheck:
-      # Match the golangci-lint v1 default surface: keep SA*
-      # (correctness) and S* (simplifications) but drop ST* (style)
-      # and QF* (quickfix refactors). Those drift away from the
-      # checks v1 ran and would expand DEP-003 scope into a rename
-      # pass, which is exactly what this ticket isn't.
-      checks:
-        - "SA*"
-        - "S1*"
-    errcheck:
-      exclude-functions:
-        - (net.Conn).Close
-        - (io.Closer).Close
-        - (*net/http.Response).Body.Close
-        - os.Unsetenv

--- a/cmd/demo/cache_step.go
+++ b/cmd/demo/cache_step.go
@@ -79,7 +79,7 @@ func readCacheCounters(ctx context.Context, cfg Config) (hits, misses float64, e
 	if err != nil {
 		return 0, 0, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		return 0, 0, fmt.Errorf("GET /metrics: status %d body=%s", res.StatusCode, body)

--- a/cmd/demo/catalog_step.go
+++ b/cmd/demo/catalog_step.go
@@ -64,7 +64,7 @@ func getInventory(ctx context.Context, cfg Config, tok, sku string) (string, []b
 	if err != nil {
 		return "", nil, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	traceID := traceFromHeader(res)
 	body, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/cmd/demo/helpers.go
+++ b/cmd/demo/helpers.go
@@ -32,7 +32,7 @@ func restPut(ctx context.Context, cfg Config, tok, url string, body any) error {
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("PUT %s: status %d body=%s", url, res.StatusCode, respBody)

--- a/cmd/demo/idempotency_step.go
+++ b/cmd/demo/idempotency_step.go
@@ -111,7 +111,7 @@ func getAvailable(ctx context.Context, cfg Config, tok, sku string) (int64, erro
 	if err != nil {
 		return 0, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		return 0, fmt.Errorf("GET inventory/%s: status %d body=%s", sku, res.StatusCode, body)

--- a/cmd/demo/steps.go
+++ b/cmd/demo/steps.go
@@ -98,7 +98,7 @@ func runRESTRoundTrip(ctx context.Context, cfg Config) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("PUT inventory: %w", err)
 	}
-	defer createRes.Body.Close()
+	defer func() { _ = createRes.Body.Close() }()
 	traceID := traceFromHeader(createRes)
 	if createRes.StatusCode != http.StatusCreated {
 		return traceID, unexpectedStatus("PUT /api/v1/inventory", createRes)
@@ -108,7 +108,7 @@ func runRESTRoundTrip(ctx context.Context, cfg Config) (string, error) {
 	if err != nil {
 		return traceID, fmt.Errorf("GET inventory/{sku}: %w", err)
 	}
-	defer getRes.Body.Close()
+	defer func() { _ = getRes.Body.Close() }()
 	if getRes.StatusCode != http.StatusOK {
 		return traceID, unexpectedStatus("GET /api/v1/inventory/{sku}", getRes)
 	}
@@ -129,7 +129,7 @@ func fetchToken(ctx context.Context, cfg Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		return "", fmt.Errorf("token endpoint status %d: %s", res.StatusCode, body)

--- a/internal/app/auth_integration_test.go
+++ b/internal/app/auth_integration_test.go
@@ -35,7 +35,7 @@ func TestTokenEndpointIssuesJWTForValidCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(res.Body)
 		t.Fatalf("status=%d body=%s", res.StatusCode, body)
@@ -73,7 +73,7 @@ func TestTokenEndpointRejectsBadCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status got=%d want=401", res.StatusCode)
 	}
@@ -88,7 +88,7 @@ func TestTokenEndpointRejectsMissingCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status got=%d want=401", res.StatusCode)
 	}
@@ -118,7 +118,7 @@ func TestProtectedRouteAcceptsBearerJWT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode == http.StatusUnauthorized {
 		t.Errorf("expected non-401 with valid bearer, got %d", res.StatusCode)
 	}
@@ -151,7 +151,7 @@ func TestProtectedRouteRejectsTamperedBearer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401 on tampered bearer, got %d", res.StatusCode)
 	}
@@ -175,7 +175,7 @@ func TestProtectedRouteRejectsBasicAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401 for Basic-Auth attempt, got %d", res.StatusCode)
 	}
@@ -199,7 +199,7 @@ func TestAdminRouteHonorsRolesClaim(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		if res.StatusCode == http.StatusUnauthorized {
 			t.Errorf("admin should reach env, got 401")
 		}
@@ -213,7 +213,7 @@ func TestAdminRouteHonorsRolesClaim(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		if res.StatusCode != http.StatusUnauthorized {
 			t.Errorf("non-admin should get 401, got %d", res.StatusCode)
 		}

--- a/internal/app/auth_metrics_integration_test.go
+++ b/internal/app/auth_metrics_integration_test.go
@@ -21,7 +21,7 @@ func readCounter(t *testing.T, ts *httptest.Server, name string) float64 {
 	if err != nil {
 		t.Fatalf("scrape /metrics: %v", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatalf("read /metrics: %v", err)
@@ -62,7 +62,7 @@ func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("Basic Auth attempt should be 401, got %d", res.StatusCode)
 	}
@@ -75,7 +75,7 @@ func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res2.Body.Close()
+	_ = res2.Body.Close()
 
 	// Failed Bearer → no counter movement.
 	req3, _ := http.NewRequest(http.MethodGet, ts.URL+app.ApiPath+app.InventoryPath, nil)
@@ -84,7 +84,7 @@ func TestAuthCountersMoveOnSuccessOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res3.Body.Close()
+	_ = res3.Body.Close()
 
 	basicAfter := readCounter(t, ts, "auth_basic_requests_total")
 	jwtAfter := readCounter(t, ts, "auth_jwt_requests_total")

--- a/internal/app/correlation_integration_test.go
+++ b/internal/app/correlation_integration_test.go
@@ -33,7 +33,7 @@ func TestCorrelationLogger_PropagatesXRequestID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 
 	got := buf.String()
 	if !strings.Contains(got, "test-123") {
@@ -58,7 +58,7 @@ func TestCorrelationLogger_GeneratesIDWhenAbsent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 
 	got := buf.String()
 	if !strings.Contains(got, `"request_id"`) {

--- a/internal/app/docs_test.go
+++ b/internal/app/docs_test.go
@@ -19,7 +19,7 @@ func TestOpenAPIYAMLServedWhenDocsEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d want=200", res.StatusCode)
@@ -45,7 +45,7 @@ func TestSwaggerUIServedWhenDocsEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("status=%d want=200", res.StatusCode)
 	}

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -75,7 +75,7 @@ func TestEnvEndpointRedactsSensitiveValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 
 	leaks := []string{dbPass, rabbitPass, dbHost, rabbitHost, dbUser, rabbitUser, springUrl, springUser, springPass}
 	for _, leak := range leaks {
@@ -105,7 +105,7 @@ func TestEnvEndpointRequiresAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401 for non-admin user, got %d", res.StatusCode)
 	}
@@ -120,7 +120,7 @@ func TestOldEnvPathIsGone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if res.StatusCode != http.StatusNotFound {
 		t.Errorf("expected 404 at unauthenticated /env, got %d", res.StatusCode)
 	}

--- a/internal/app/ratelimit_routes_test.go
+++ b/internal/app/ratelimit_routes_test.go
@@ -61,7 +61,7 @@ func TestGlobalRateLimitAppliesToProtectedRoutesNotProbes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode != http.StatusTooManyRequests {
 			t.Errorf("api status=%d, want 429", res.StatusCode)
 		}
@@ -77,7 +77,7 @@ func TestGlobalRateLimitAppliesToProtectedRoutesNotProbes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			res.Body.Close()
+			_ = res.Body.Close()
 			if res.StatusCode == http.StatusTooManyRequests {
 				t.Errorf("%s returned 429; probes must bypass the limiter", path)
 			}
@@ -121,7 +121,7 @@ func TestBodyLimitMiddlewareRejectsOversizePost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Errorf("status=%d, want 413 (body cap fires before auth)", res.StatusCode)
@@ -156,7 +156,7 @@ func TestBodyLimitDoesNotApplyToProbes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		if res.StatusCode == http.StatusRequestEntityTooLarge {
 			t.Errorf("%s returned 413; probes must bypass the body cap", path)
 		}

--- a/internal/app/routes_test.go
+++ b/internal/app/routes_test.go
@@ -148,7 +148,7 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer res.Body.Close()
+			defer func() { _ = res.Body.Close() }()
 			if res.StatusCode != http.StatusUnauthorized {
 				t.Errorf("expected 401 for unauthenticated %s, got %d", test.path, res.StatusCode)
 			}
@@ -165,7 +165,7 @@ func TestApiRoutesRequireAuthentication(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer res.Body.Close()
+			defer func() { _ = res.Body.Close() }()
 			if res.StatusCode != http.StatusUnauthorized {
 				t.Errorf("expected 401 for Basic-Auth attempt on %s, got %d", test.path, res.StatusCode)
 			}
@@ -187,7 +187,7 @@ func TestUnauthenticatedEndpointsRemainOpen(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GET %s: %v", p, err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		if res.StatusCode == http.StatusUnauthorized {
 			t.Errorf("expected %s to be reachable without auth, got 401", p)
 		}

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -60,7 +60,7 @@ func TestNewWithDepsConstructibleInTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("/live got status %d, want 200", res.StatusCode)

--- a/internal/inventory/problem_integration_test.go
+++ b/internal/inventory/problem_integration_test.go
@@ -31,7 +31,7 @@ func TestProblemResponseConformsToRFC7807(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("status got=%d want=500", res.StatusCode)

--- a/internal/inventory/transport_http.go
+++ b/internal/inventory/transport_http.go
@@ -103,7 +103,7 @@ func (a *InventoryApi) Subscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	go func() {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		streamInventoryToClient(a.service, wsTextWriter{conn: conn})
 	}()
 }

--- a/internal/inventory/transport_http_reservation.go
+++ b/internal/inventory/transport_http_reservation.go
@@ -75,7 +75,7 @@ func (a *ReservationApi) Subscribe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	go func() {
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		streamReservationsToClient(a.service, wsTextWriter{conn: conn})
 	}()
 }

--- a/internal/inventory/transport_http_reservation_test.go
+++ b/internal/inventory/transport_http_reservation_test.go
@@ -198,7 +198,7 @@ func TestReservationGetBadID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusBadRequest {
 		t.Errorf("status code got=%d want=%d", res.StatusCode, http.StatusBadRequest)

--- a/internal/platform/httpx/pagination_test.go
+++ b/internal/platform/httpx/pagination_test.go
@@ -47,7 +47,7 @@ func TestPaginationRejectsInvalidInput(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer res.Body.Close()
+			defer func() { _ = res.Body.Close() }()
 			if res.StatusCode != http.StatusBadRequest {
 				t.Fatalf("status got=%d want=400", res.StatusCode)
 			}
@@ -90,7 +90,7 @@ func TestPaginationDefaultsAndClamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if gotLimit != httpx.DefaultPageLimit {
 		t.Errorf("default limit got=%d want=%d", gotLimit, httpx.DefaultPageLimit)
 	}
@@ -103,7 +103,7 @@ func TestPaginationDefaultsAndClamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res.Body.Close()
+	_ = res.Body.Close()
 	if gotLimit != httpx.MaxPageLimit {
 		t.Errorf("boundary limit got=%d want=%d", gotLimit, httpx.MaxPageLimit)
 	}
@@ -121,7 +121,7 @@ func TestPaginationLinkHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		link := res.Header.Get("Link")
 		if !strings.Contains(link, `rel="next"`) {
 			t.Errorf("expected next rel in Link header, got %q", link)
@@ -142,7 +142,7 @@ func TestPaginationLinkHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		link := res.Header.Get("Link")
 		if !strings.Contains(link, `rel="next"`) || !strings.Contains(link, `rel="prev"`) {
 			t.Errorf("expected both next and prev, got %q", link)
@@ -163,7 +163,7 @@ func TestPaginationLinkHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		res.Body.Close()
+		_ = res.Body.Close()
 		link := res.Header.Get("Link")
 		if strings.Contains(link, `rel="next"`) {
 			t.Errorf("did not expect next on partial page, got %q", link)

--- a/internal/platform/messaging/kafka/consumer.go
+++ b/internal/platform/messaging/kafka/consumer.go
@@ -32,20 +32,20 @@ type Consumer struct {
 	dltTopic string
 	group    string
 
-	maxRetries  int
-	retryBaseMs time.Duration
+	maxRetries int
+	retryBase  time.Duration
 }
 
 // ConsumerConfig collects the wiring options. Producer/Handler/etc.
 // are all required; the retry knobs default to 3 retries / 200ms base.
 type ConsumerConfig struct {
-	Brokers     []string
-	Topic       string
-	DLTTopic    string
-	Group       string
-	Handler     Handler
-	MaxRetries  int
-	RetryBaseMs time.Duration
+	Brokers    []string
+	Topic      string
+	DLTTopic   string
+	Group      string
+	Handler    Handler
+	MaxRetries int
+	RetryBase  time.Duration
 }
 
 // NewConsumer builds the consumer client and a small dedicated DLT
@@ -87,20 +87,20 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 	if max <= 0 {
 		max = 3
 	}
-	base := cfg.RetryBaseMs
+	base := cfg.RetryBase
 	if base <= 0 {
 		base = 200 * time.Millisecond
 	}
 
 	return &Consumer{
-		client:      client,
-		dltProd:     dltProd,
-		handler:     cfg.Handler,
-		topic:       cfg.Topic,
-		dltTopic:    cfg.DLTTopic,
-		group:       cfg.Group,
-		maxRetries:  max,
-		retryBaseMs: base,
+		client:     client,
+		dltProd:    dltProd,
+		handler:    cfg.Handler,
+		topic:      cfg.Topic,
+		dltTopic:   cfg.DLTTopic,
+		group:      cfg.Group,
+		maxRetries: max,
+		retryBase:  base,
 	}, nil
 }
 
@@ -172,7 +172,7 @@ func (c *Consumer) dispatch(parent context.Context, rec *kgo.Record) {
 			c.toDLT(parent, rec, err.Error())
 			return
 		}
-		backoff := c.retryBaseMs * time.Duration(1<<attempt)
+		backoff := c.retryBase * time.Duration(1<<attempt)
 		select {
 		case <-parent.Done():
 			return

--- a/internal/platform/secrets/provider_test.go
+++ b/internal/platform/secrets/provider_test.go
@@ -21,7 +21,7 @@ func TestEnvProviderPasses(t *testing.T) {
 func TestEnvProviderReportsMissing(t *testing.T) {
 	// Prefix unlikely to exist in CI
 	const v = "GME_TEST_DOES_NOT_EXIST"
-	os.Unsetenv(v)
+	_ = os.Unsetenv(v)
 	err := (secrets.EnvProvider{}).Load([]secrets.EnvVar{secrets.EnvVar(v)})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -39,8 +39,8 @@ func TestFileProviderReadsAndExports(t *testing.T) {
 	}
 
 	t.Setenv(v, "") // ensure unset before
-	os.Unsetenv(v)
-	t.Cleanup(func() { os.Unsetenv(v) })
+	_ = os.Unsetenv(v)
+	t.Cleanup(func() { _ = os.Unsetenv(v) })
 
 	if err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{secrets.EnvVar(v)}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -58,7 +58,7 @@ func TestFileProviderPreservesInternalWhitespace(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "gme_test_internal_ws"), []byte("a b\nc\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Unsetenv(v) })
+	t.Cleanup(func() { _ = os.Unsetenv(v) })
 	if err := (secrets.FileProvider{Dir: dir}).Load([]secrets.EnvVar{secrets.EnvVar(v)}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/user/dto.go
+++ b/internal/user/dto.go
@@ -15,7 +15,7 @@ func (p *CreateUserRequestDto) Bind(_ *http.Request) error {
 		return errors.New("missing required field(s)")
 	}
 
-	p.CreateUserRequest.PlainTextPassword = p.Password
+	p.PlainTextPassword = p.Password
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Ticket: [OPS-010](plan/OPS-010-full-linter-surface.md) — lift the linter filters DEP-003 introduced (and OPS-003 kept) and fix every previously-suppressed finding rather than paper over it.

`.golangci.yml` now carries only the affirmative config: `formatters.enable: [gofumpt]`, `linters.default: standard`, `linters.enable: [errorlint, errname]`. No `staticcheck.checks` filter, no `errcheck.exclude-functions`, no `// nolint:` directives — every previous suppression turned out to be real signal worth fixing.

## Findings fixed

| Family | Sites | Fix |
| --- | --- | --- |
| `errcheck` on `*Response.Body.Close()` | ~20 across `cmd/demo`, `internal/app`, `internal/platform`, `internal/inventory` | Production paths get `defer func() { _ = res.Body.Close() }()`; one-shot test closes get `_ = res.Body.Close()`. Matches the `session.Close` pattern landed in TST-003. |
| `errcheck` on `(*net.Conn).Close()` in the WS Subscribe handlers | 2 (inventory + reservation) | Same idiom. |
| `errcheck` on `os.Unsetenv` in `secrets/provider_test.go` | 3 | Explicit `_ =`. `Unsetenv` only fails for an invalid name; impossible with hard-coded constants. |
| `staticcheck ST1011` in `kafka/consumer.go` | 2 | `retryBaseMs` / `RetryBaseMs` → `retryBase` / `RetryBase`. The `time.Duration` type already encodes the unit. No external callers. |
| `staticcheck QF1008` in `user/dto.go` | 1 | `p.CreateUserRequest.PlainTextPassword` → `p.PlainTextPassword`. Go promotes embedded fields. |

## What didn't surface

The OPS-010 ticket's table predicted `ST1003` naming findings (`ConnectDb` → `ConnectDB`, `getUrl` → `getURL`, `requestId` → `requestID`) and `ST1000` package-comment findings. Neither appeared — the codebase is already clean on those, and `default: standard` in golangci-lint v2.12.2 doesn't include `ST1003` in the activated set. No renames needed.

## Acceptance criteria

- [x] `.golangci.yml` has no `staticcheck.checks` filter and no `errcheck.exclude-functions`.
- [x] `golangci-lint run` passes with the v2 default linter set on the project's pinned version (v2.12.2).
- [x] No `// nolint:` directives added.
- [x] `make verify` clean.

## Verification

```
$ golangci-lint run
0 issues.

$ make verify
==> verify OK
```

## Test plan

- [ ] CI lint job stays green.
- [ ] No behavioural change — every fix is either a discarded error (Close on a defer'd path) or a rename without external callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)