### PR TITLE
SEC-015: fix latent FOR UPDATE double-concat

### DIFF
--- a/internal/inventory/repository.go
+++ b/internal/inventory/repository.go
@@ -151,7 +151,7 @@ func (d *dbRepo) GetProductionEventByRequestID(ctx context.Context, requestID st
 	tx, forUpdate := persistence.GetQueryOptions(d.conn, options...)
 
 	pe = ProductionEvent{}
-	err = tx.QueryRow(ctx, `SELECT id, request_id, sku, quantity, created FROM production_events `+forUpdate+` WHERE request_id = $1 `+forUpdate, requestID).
+	err = tx.QueryRow(ctx, `SELECT id, request_id, sku, quantity, created FROM production_events WHERE request_id = $1 `+forUpdate, requestID).
 		Scan(&pe.ID, &pe.RequestID, &pe.Sku, &pe.Quantity, &pe.Created)
 	if err != nil {
 		m.Complete(err)

--- a/internal/inventory/repository_test.go
+++ b/internal/inventory/repository_test.go
@@ -255,6 +255,41 @@ func TestRepositoryGetProductionEventByRequestID(t *testing.T) {
 	}
 }
 
+// TestRepositoryGetProductionEventByRequestID_ForUpdate is the
+// SEC-015 regression: GetProductionEventByRequestID used to
+// concatenate `forUpdate` twice — once after `FROM production_events`
+// and once after the `WHERE` clause — which rendered an invalid
+// PostgreSQL statement the moment any caller asked for FOR UPDATE
+// semantics. The anchored regex below would fail to match either
+// the pre-fix double-clause form or any positioning other than
+// "exactly once, at the end".
+func TestRepositoryGetProductionEventByRequestID_ForUpdate(t *testing.T) {
+	repo, mock := newRepo(t)
+	mock.ExpectBegin()
+	created := time.Unix(0, 0).UTC()
+	pattern := `^SELECT id, request_id, sku, quantity, created FROM production_events WHERE request_id = \$1 FOR UPDATE\s*$`
+	mock.ExpectQuery(pattern).
+		WithArgs("req1").
+		WillReturnRows(pgxmock.NewRows([]string{"id", "request_id", "sku", "quantity", "created"}).
+			AddRow(uint64(7), "req1", "sku1", int64(3), created))
+
+	tx, err := repo.BeginTransaction(context.Background())
+	if err != nil {
+		t.Fatalf("BeginTransaction: %v", err)
+	}
+	got, err := repo.GetProductionEventByRequestID(context.Background(), "req1",
+		persistence.QueryOptions{Tx: tx, ForUpdate: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != 7 {
+		t.Errorf("ID got=%d want=7", got.ID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
 func TestRepositorySaveReservation(t *testing.T) {
 	repo, mock := newRepo(t)
 	r := &inventory.Reservation{


### PR DESCRIPTION
## Summary

Ticket: [SEC-015](plan/SEC-015-production-event-foreupdate.md) — the last open SEC item (modulo the user-deferred SEC-012). Surgical 3-line trim plus a regression test.

`GetProductionEventByRequestID` had `+forUpdate+` twice in the query string — once between `FROM production_events` and the `WHERE` clause, and once again at the tail. With `forUpdate == ""` (the only path the current caller exercises) both expand to empty strings and nothing breaks. The moment any caller asks for `FOR UPDATE` semantics via `persistence.QueryOptions{ForUpdate: true}`, the rendered SQL becomes

```sql
SELECT ... FROM production_events FOR UPDATE WHERE request_id = $1 FOR UPDATE
```

which PostgreSQL rejects — only one `FOR UPDATE` clause is allowed and it must come after the `WHERE`.

## Fix

Three-line diff: drop the mid-statement concatenation, keep the tail one. Same shape as every other `dbRepo` method.

## Test

`TestRepositoryGetProductionEventByRequestID_ForUpdate` opens a transaction, calls `GetProductionEventByRequestID` with `Tx: tx, ForUpdate: true`, and asserts the rendered SQL against an anchored regex with `FOR UPDATE` exactly once at the tail:

```go
pattern := `^SELECT id, request_id, sku, quantity, created FROM production_events WHERE request_id = \$1 FOR UPDATE\s*$`
```

The pre-fix double-clause form failed this match — the regex requires `WHERE` directly after `production_events`, not `FOR UPDATE WHERE`.

## Acceptance criteria

- [x] `forUpdate` suffix is concatenated once, after the `WHERE` clause.
- [x] Repository-level test exercises the FOR UPDATE branch and asserts the rendered SQL.

## Verification

```
$ make verify
==> verify OK

$ go test ./internal/inventory -run TestRepositoryGetProductionEventByRequestID -v
--- PASS: TestRepositoryGetProductionEventByRequestID (0.00s)
--- PASS: TestRepositoryGetProductionEventByRequestID_ForUpdate (0.00s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)