### PR TITLE
DSN-004b: service-layer custom spans

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -30,13 +30,22 @@ focuses.
   TraceContext propagation, so future outbound HTTP calls or
   gRPC clients pick up the active span automatically.
 
-### What's not yet instrumented
+### Service-layer spans (DSN-004b)
 
-- **Service-layer custom spans** (e.g. `inventory.Service.Reserve`).
-  The chi+pgx auto-instrumentation already covers ~80% of the
-  signal a typical request needs; explicit business-operation
-  spans are a follow-up. File a follow-up ticket if traces
-  surface a gap that the auto-instrumentation can't fill.
+Every exported method on `inventory.Service` and `user.Service`
+opens an `INTERNAL`-kind span named after the method
+(`inventory.Service.Reserve`, `user.Service.Login`, etc.) with the
+relevant business identifiers as attributes: `inventory.sku`,
+`request_id`, `inventory.reservation_id`, `user.username`. Errors
+returned by the method are recorded via `span.RecordError` and the
+span status flips to `Error`. The plumbing lives in
+`observability.StartServiceSpan`, a helper that returns a finisher
+closure callers `defer` with their named-error return.
+
+These spans sit between otelchi's HTTP root and otelpgx's per-query
+spans, so traces of a fanout request (one HTTP call → many DB
+calls) make it obvious which DB spans came from which service
+operation.
 
 ### Configuration
 

--- a/internal/inventory/service.go
+++ b/internal/inventory/service.go
@@ -94,12 +94,11 @@ func (s *service) SetCache(c cache.Cache, ttl time.Duration) {
 func productCacheKey(sku string) string { return "inv:product:" + sku + ":v1" }
 
 func (s *service) CreateProduct(ctx context.Context, product Product) (err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "CreateProduct",
+	const funcName = "CreateProduct"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", product.Sku),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "CreateProduct"
 
 	dbProduct, err := s.repo.GetProduct(ctx, product.Sku)
 	if err != nil && !errors.Is(err, persistence.ErrNotFound) {
@@ -140,14 +139,13 @@ func (s *service) CreateProduct(ctx context.Context, product Product) (err error
 }
 
 func (s *service) Produce(ctx context.Context, product Product, pr ProductionRequest) (err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Produce",
+	const funcName = "Produce"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", product.Sku),
 		attribute.String("request_id", pr.RequestID),
 		attribute.Int64("inventory.quantity", pr.Quantity),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "Produce"
 
 	log.Ctx(ctx).Debug().
 		Str("func", funcName).
@@ -221,15 +219,14 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 }
 
 func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (res Reservation, err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Reserve",
+	const funcName = "Reserve"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", rr.Sku),
 		attribute.String("request_id", rr.RequestID),
 		attribute.String("inventory.requester", rr.Requester),
 		attribute.Int64("inventory.quantity", rr.Quantity),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "Reserve"
 
 	log.Ctx(ctx).Debug().
 		Str("func", funcName).
@@ -318,12 +315,11 @@ func (s *service) GetAllProductInventory(ctx context.Context, limit, offset int)
 }
 
 func (s *service) GetProduct(ctx context.Context, sku string) (product Product, err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetProduct",
+	const funcName = "GetProduct"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", sku),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "GetProduct"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product")
 
@@ -335,12 +331,11 @@ func (s *service) GetProduct(ctx context.Context, sku string) (product Product, 
 }
 
 func (s *service) GetProductInventory(ctx context.Context, sku string) (product ProductInventory, err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetProductInventory",
+	const funcName = "GetProductInventory"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", sku),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "GetProductInventory"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product inventory")
 
@@ -369,7 +364,8 @@ func (s *service) GetProductInventory(ctx context.Context, sku string) (product 
 }
 
 func (s *service) GetReservation(ctx context.Context, ID uint64) (rsv Reservation, err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetReservation",
+	const funcName = "GetReservation"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		// Format as a string: reservation IDs come from a Postgres
 		// uint64 sequence and OTel's only numeric attribute helper
 		// is Int64, which gosec G115 flags as an unchecked overflow
@@ -377,8 +373,6 @@ func (s *service) GetReservation(ctx context.Context, ID uint64) (rsv Reservatio
 		attribute.String("inventory.reservation_id", strconv.FormatUint(ID, 10)),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "GetReservation"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Uint64("id", ID).Msg("getting reservation")
 
@@ -390,15 +384,14 @@ func (s *service) GetReservation(ctx context.Context, ID uint64) (rsv Reservatio
 }
 
 func (s *service) GetReservations(ctx context.Context, options GetReservationsOptions, limit, offset int) (rsv []Reservation, err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetReservations",
+	const funcName = "GetReservations"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", options.Sku),
 		attribute.String("inventory.state", string(options.State)),
 		attribute.Int("inventory.limit", limit),
 		attribute.Int("inventory.offset", offset),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "GetReservations"
 
 	log.Ctx(ctx).Debug().
 		Str("func", funcName).
@@ -452,12 +445,11 @@ func (s *service) UnsubscribeReservations(id ReservationsSubID) {
 }
 
 func (s *service) FillReserves(ctx context.Context, product Product) (err error) {
-	ctx, end := observability.StartServiceSpan(ctx, tracerName, "FillReserves",
+	const funcName = "FillReserves"
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, funcName,
 		attribute.String("inventory.sku", product.Sku),
 	)
 	defer func() { end(err) }()
-
-	const funcName = "fillReserves"
 
 	tx, err := s.repo.BeginTransaction(ctx)
 	defer func() {

--- a/internal/inventory/service.go
+++ b/internal/inventory/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -11,8 +12,14 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
 	"github.com/sksmith/go-micro-example/internal/platform/cache"
+	"github.com/sksmith/go-micro-example/internal/platform/observability"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
+	"go.opentelemetry.io/otel/attribute"
 )
+
+// tracerName is the instrumentation name reported on every service
+// span in this package (DSN-004b).
+const tracerName = "inventory.Service"
 
 // ErrInvalidInput is the sentinel for validation failures produced
 // by this package's service methods (missing fields, out-of-range
@@ -86,7 +93,12 @@ func (s *service) SetCache(c cache.Cache, ttl time.Duration) {
 // matters when the cached shape changes (DSN-020).
 func productCacheKey(sku string) string { return "inv:product:" + sku + ":v1" }
 
-func (s *service) CreateProduct(ctx context.Context, product Product) error {
+func (s *service) CreateProduct(ctx context.Context, product Product) (err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "CreateProduct",
+		attribute.String("inventory.sku", product.Sku),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "CreateProduct"
 
 	dbProduct, err := s.repo.GetProduct(ctx, product.Sku)
@@ -127,7 +139,14 @@ func (s *service) CreateProduct(ctx context.Context, product Product) error {
 	return nil
 }
 
-func (s *service) Produce(ctx context.Context, product Product, pr ProductionRequest) error {
+func (s *service) Produce(ctx context.Context, product Product, pr ProductionRequest) (err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Produce",
+		attribute.String("inventory.sku", product.Sku),
+		attribute.String("request_id", pr.RequestID),
+		attribute.Int64("inventory.quantity", pr.Quantity),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "Produce"
 
 	log.Ctx(ctx).Debug().
@@ -201,7 +220,15 @@ func (s *service) Produce(ctx context.Context, product Product, pr ProductionReq
 	return nil
 }
 
-func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservation, error) {
+func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (res Reservation, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Reserve",
+		attribute.String("inventory.sku", rr.Sku),
+		attribute.String("request_id", rr.RequestID),
+		attribute.String("inventory.requester", rr.Requester),
+		attribute.Int64("inventory.quantity", rr.Quantity),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "Reserve"
 
 	log.Ctx(ctx).Debug().
@@ -231,7 +258,7 @@ func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (Reservati
 		return Reservation{}, fmt.Errorf("get product %q: %w", rr.Sku, err)
 	}
 
-	res, err := s.repo.GetReservationByRequestID(ctx, rr.RequestID, persistence.QueryOptions{Tx: tx, ForUpdate: true})
+	res, err = s.repo.GetReservationByRequestID(ctx, rr.RequestID, persistence.QueryOptions{Tx: tx, ForUpdate: true})
 	if err != nil && !errors.Is(err, persistence.ErrNotFound) {
 		return Reservation{}, fmt.Errorf("get reservation by request id %q: %w", rr.RequestID, err)
 	}
@@ -281,23 +308,38 @@ func validateReservationRequest(rr ReservationRequest) error {
 	return nil
 }
 
-func (s *service) GetAllProductInventory(ctx context.Context, limit, offset int) ([]ProductInventory, error) {
+func (s *service) GetAllProductInventory(ctx context.Context, limit, offset int) (out []ProductInventory, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetAllProductInventory",
+		attribute.Int("inventory.limit", limit),
+		attribute.Int("inventory.offset", offset),
+	)
+	defer func() { end(err) }()
 	return s.repo.GetAllProductInventory(ctx, limit, offset)
 }
 
-func (s *service) GetProduct(ctx context.Context, sku string) (Product, error) {
+func (s *service) GetProduct(ctx context.Context, sku string) (product Product, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetProduct",
+		attribute.String("inventory.sku", sku),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "GetProduct"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product")
 
-	product, err := s.repo.GetProduct(ctx, sku)
+	product, err = s.repo.GetProduct(ctx, sku)
 	if err != nil {
 		return product, err
 	}
 	return product, nil
 }
 
-func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductInventory, error) {
+func (s *service) GetProductInventory(ctx context.Context, sku string) (product ProductInventory, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetProductInventory",
+		attribute.String("inventory.sku", sku),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "GetProductInventory"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Str("sku", sku).Msg("getting product inventory")
@@ -313,7 +355,7 @@ func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductI
 		}
 	}
 
-	product, err := s.repo.GetProductInventory(ctx, sku)
+	product, err = s.repo.GetProductInventory(ctx, sku)
 	if err != nil {
 		return product, err
 	}
@@ -326,19 +368,36 @@ func (s *service) GetProductInventory(ctx context.Context, sku string) (ProductI
 	return product, nil
 }
 
-func (s *service) GetReservation(ctx context.Context, ID uint64) (Reservation, error) {
+func (s *service) GetReservation(ctx context.Context, ID uint64) (rsv Reservation, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetReservation",
+		// Format as a string: reservation IDs come from a Postgres
+		// uint64 sequence and OTel's only numeric attribute helper
+		// is Int64, which gosec G115 flags as an unchecked overflow
+		// conversion. Trace UIs render numeric strings fine.
+		attribute.String("inventory.reservation_id", strconv.FormatUint(ID, 10)),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "GetReservation"
 
 	log.Ctx(ctx).Debug().Str("func", funcName).Uint64("id", ID).Msg("getting reservation")
 
-	rsv, err := s.repo.GetReservation(ctx, ID)
+	rsv, err = s.repo.GetReservation(ctx, ID)
 	if err != nil {
 		return rsv, err
 	}
 	return rsv, nil
 }
 
-func (s *service) GetReservations(ctx context.Context, options GetReservationsOptions, limit, offset int) ([]Reservation, error) {
+func (s *service) GetReservations(ctx context.Context, options GetReservationsOptions, limit, offset int) (rsv []Reservation, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "GetReservations",
+		attribute.String("inventory.sku", options.Sku),
+		attribute.String("inventory.state", string(options.State)),
+		attribute.Int("inventory.limit", limit),
+		attribute.Int("inventory.offset", offset),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "GetReservations"
 
 	log.Ctx(ctx).Debug().
@@ -347,7 +406,7 @@ func (s *service) GetReservations(ctx context.Context, options GetReservationsOp
 		Str("state", string(options.State)).
 		Msg("getting reservations")
 
-	rsv, err := s.repo.GetReservations(ctx, options, limit, offset)
+	rsv, err = s.repo.GetReservations(ctx, options, limit, offset)
 	if err != nil {
 		return rsv, err
 	}
@@ -392,7 +451,12 @@ func (s *service) UnsubscribeReservations(id ReservationsSubID) {
 	s.subsMu.Unlock()
 }
 
-func (s *service) FillReserves(ctx context.Context, product Product) error {
+func (s *service) FillReserves(ctx context.Context, product Product) (err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "FillReserves",
+		attribute.String("inventory.sku", product.Sku),
+	)
+	defer func() { end(err) }()
+
 	const funcName = "fillReserves"
 
 	tx, err := s.repo.BeginTransaction(ctx)

--- a/internal/inventory/service_test.go
+++ b/internal/inventory/service_test.go
@@ -14,7 +14,45 @@ import (
 	"github.com/sksmith/go-micro-example/internal/platform/cache"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
 	"github.com/sksmith/go-micro-example/internal/testutil"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+// withRecordingTracer swaps the global TracerProvider for the
+// duration of one test. Mirrors the helper in the user package
+// (see user/service_test.go) and the amqp package (DSN-004a) —
+// the same shape works everywhere because Tracer/SetTracerProvider
+// are package-level globals.
+func withRecordingTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+	})
+	return recorder
+}
+
+func hasStringAttr(span sdktrace.ReadOnlySpan, key, val string) bool {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key && kv.Value.AsString() == val {
+			return true
+		}
+	}
+	return false
+}
 
 func TestMain(m *testing.M) {
 	testutil.ConfigLogging()
@@ -1393,4 +1431,83 @@ func TestProduceInvalidatesCache(t *testing.T) {
 	if c.Size() != 0 {
 		t.Errorf("cache size=%d after Produce; want 0 (invalidation should have dropped sku3)", c.Size())
 	}
+}
+
+// TestInventoryService_SpansHappyAndError pins DSN-004b's contract on
+// the inventory side: every exported method produces a span named
+// after the method with the sku attribute populated, and errors are
+// recorded on the span via RecordError + SetStatus(Error).
+func TestInventoryService_SpansHappyAndError(t *testing.T) {
+	t.Run("happy path: GetProductInventory records span without error", func(t *testing.T) {
+		recorder := withRecordingTracer(t)
+
+		mockRepo := inventory.NewMockRepo()
+		mockRepo.GetProductInventoryFunc = func(_ context.Context, _ string, _ ...persistence.QueryOptions) (inventory.ProductInventory, error) {
+			return inventory.ProductInventory{Product: inventory.Product{Sku: "sku-1"}, Available: 3}, nil
+		}
+		mockQ := &inventoryPublisherStub{}
+		svc := inventory.NewService(mockRepo, mockQ)
+
+		if _, err := svc.GetProductInventory(context.Background(), "sku-1"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		spans := recorder.Ended()
+		if len(spans) != 1 {
+			t.Fatalf("recorded %d spans, want 1", len(spans))
+		}
+		got := spans[0]
+		if got.Name() != "GetProductInventory" {
+			t.Errorf("span name = %q, want GetProductInventory", got.Name())
+		}
+		if got.Status().Code.String() == "Error" {
+			t.Errorf("happy path should not be Error: %q (%q)",
+				got.Status().Code.String(), got.Status().Description)
+		}
+		if !hasStringAttr(got, "inventory.sku", "sku-1") {
+			t.Errorf("missing inventory.sku=sku-1; got %+v", got.Attributes())
+		}
+	})
+
+	t.Run("error path: Reserve validation failure records error", func(t *testing.T) {
+		recorder := withRecordingTracer(t)
+
+		svc := inventory.NewService(inventory.NewMockRepo(), &inventoryPublisherStub{})
+
+		// Empty RequestID → validateReservationRequest returns
+		// ErrInvalidInput before any repo call, exercising the
+		// error path without needing a mock to fail.
+		_, err := svc.Reserve(context.Background(), inventory.ReservationRequest{Sku: "sku-1", Requester: "r", Quantity: 1})
+		if !errors.Is(err, inventory.ErrInvalidInput) {
+			t.Fatalf("expected ErrInvalidInput, got %v", err)
+		}
+
+		spans := recorder.Ended()
+		if len(spans) != 1 {
+			t.Fatalf("recorded %d spans, want 1", len(spans))
+		}
+		got := spans[0]
+		if got.Name() != "Reserve" {
+			t.Errorf("span name = %q, want Reserve", got.Name())
+		}
+		if got.Status().Code.String() != "Error" {
+			t.Errorf("error path should set status Error, got %q",
+				got.Status().Code.String())
+		}
+		if len(got.Events()) == 0 {
+			t.Errorf("RecordError should have added an event; got none")
+		}
+	})
+}
+
+// inventoryPublisherStub satisfies inventory.InventoryPublisher with
+// no-op methods so service span tests don't need to stand up AMQP.
+type inventoryPublisherStub struct{}
+
+func (inventoryPublisherStub) PublishInventory(_ context.Context, _ inventory.ProductInventory) error {
+	return nil
+}
+
+func (inventoryPublisherStub) PublishReservation(_ context.Context, _ inventory.Reservation) error {
+	return nil
 }

--- a/internal/platform/observability/tracing.go
+++ b/internal/platform/observability/tracing.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -137,6 +139,34 @@ func ResolveSamplingRatio(defaultRatio float64) float64 {
 // imports.
 func Tracer(name string) trace.Tracer {
 	return otel.Tracer(name)
+}
+
+// StartServiceSpan opens a span on the named tracer with the given
+// span name and attributes and returns the new ctx plus a finisher
+// closure. Callers deferred-invoke the closure with their named
+// error return — non-nil error records the error on the span and
+// flips its status to Error before End. This is the boilerplate
+// every internal service method runs through for DSN-004b's
+// business-operation tracing.
+//
+// Pattern:
+//
+//	func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (res Reservation, err error) {
+//	    ctx, end := observability.StartServiceSpan(ctx, "inventory.Service", "Reserve",
+//	        attribute.String("sku", rr.Sku),
+//	    )
+//	    defer func() { end(err) }()
+//	    // ... body ...
+//	}
+func StartServiceSpan(ctx context.Context, tracerName, spanName string, attrs ...attribute.KeyValue) (context.Context, func(error)) {
+	ctx, span := Tracer(tracerName).Start(ctx, spanName, trace.WithAttributes(attrs...))
+	return ctx, func(err error) {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}
 }
 
 // flushTimeout caps how long shutdown will wait for the batch

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -7,9 +7,15 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/sksmith/go-micro-example/internal/platform/observability"
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// tracerName is the instrumentation name reported on every service
+// span in this package (DSN-004b).
+const tracerName = "user.Service"
 
 // ErrInvalidCredentials is returned by Login when the username does
 // not exist or the supplied password does not match. The two cases
@@ -33,11 +39,19 @@ type service struct {
 	repo Repository
 }
 
-func (s *service) Get(ctx context.Context, username string) (User, error) {
+func (s *service) Get(ctx context.Context, username string) (u User, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Get",
+		attribute.String("user.username", username),
+	)
+	defer func() { end(err) }()
 	return s.repo.Get(ctx, username)
 }
 
-func (s *service) Create(ctx context.Context, req CreateUserRequest) (User, error) {
+func (s *service) Create(ctx context.Context, req CreateUserRequest) (u User, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Create",
+		attribute.String("user.username", req.Username),
+	)
+	defer func() { end(err) }()
 	if !usernameIsValid(req.Username) {
 		return User{}, fmt.Errorf("invalid username: %w", ErrInvalidInput)
 	}
@@ -68,12 +82,20 @@ func passwordIsValid(password string) bool {
 	return true
 }
 
-func (s *service) Delete(ctx context.Context, username string) error {
+func (s *service) Delete(ctx context.Context, username string) (err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Delete",
+		attribute.String("user.username", username),
+	)
+	defer func() { end(err) }()
 	return s.repo.Delete(ctx, username)
 }
 
-func (s *service) Login(ctx context.Context, username, password string) (User, error) {
-	u, err := s.repo.Get(ctx, username)
+func (s *service) Login(ctx context.Context, username, password string) (u User, err error) {
+	ctx, end := observability.StartServiceSpan(ctx, tracerName, "Login",
+		attribute.String("user.username", username),
+	)
+	defer func() { end(err) }()
+	u, err = s.repo.Get(ctx, username)
 	if err != nil {
 		if errors.Is(err, persistence.ErrNotFound) {
 			return User{}, ErrInvalidCredentials

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -9,7 +9,36 @@ import (
 
 	"github.com/sksmith/go-micro-example/internal/platform/persistence"
 	"github.com/sksmith/go-micro-example/internal/user"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// withRecordingTracer swaps the global TracerProvider for the
+// duration of one test and returns a SpanRecorder so DSN-004b's
+// service-layer span assertions can read what the methods produced.
+// Restores prior globals on cleanup so tests stay independent.
+func withRecordingTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+	})
+	return recorder
+}
 
 func TestGet(t *testing.T) {
 	usr := user.User{Username: "someuser", HashedPassword: "somehashedpassword", IsAdmin: false, Created: time.Now()}
@@ -253,4 +282,87 @@ func TestLogin(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUserService_SpansHappyAndError pins DSN-004b's contract on the
+// user side: every exported service method records exactly one span
+// per call, named after the method, with the username attribute set;
+// methods that returned an error mark the span Error and record the
+// error message via RecordError.
+func TestUserService_SpansHappyAndError(t *testing.T) {
+	t.Run("happy path: Get records span without error", func(t *testing.T) {
+		recorder := withRecordingTracer(t)
+
+		mockRepo := user.NewMockRepo()
+		mockRepo.GetFunc = func(_ context.Context, _ string, _ ...persistence.QueryOptions) (user.User, error) {
+			return user.User{Username: "alice"}, nil
+		}
+		svc := user.NewService(mockRepo)
+
+		if _, err := svc.Get(context.Background(), "alice"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		spans := recorder.Ended()
+		if len(spans) != 1 {
+			t.Fatalf("recorded %d spans, want 1", len(spans))
+		}
+		got := spans[0]
+		if got.Name() != "Get" {
+			t.Errorf("span name = %q, want %q", got.Name(), "Get")
+		}
+		if got.SpanKind() != trace.SpanKindInternal {
+			t.Errorf("kind = %v, want internal", got.SpanKind())
+		}
+		if got.Status().Code.String() == "Error" {
+			t.Errorf("happy path should not set status Error, got %q (%q)",
+				got.Status().Code.String(), got.Status().Description)
+		}
+		if !hasStringAttr(got, "user.username", "alice") {
+			t.Errorf("missing user.username=alice attr; got %+v", got.Attributes())
+		}
+	})
+
+	t.Run("error path: Login records error on span", func(t *testing.T) {
+		recorder := withRecordingTracer(t)
+
+		mockRepo := user.NewMockRepo()
+		mockRepo.GetFunc = func(_ context.Context, _ string, _ ...persistence.QueryOptions) (user.User, error) {
+			return user.User{}, persistence.ErrNotFound
+		}
+		svc := user.NewService(mockRepo)
+
+		_, err := svc.Login(context.Background(), "ghost", "pw")
+		if !errors.Is(err, user.ErrInvalidCredentials) {
+			t.Fatalf("expected ErrInvalidCredentials, got %v", err)
+		}
+
+		spans := recorder.Ended()
+		if len(spans) != 1 {
+			t.Fatalf("recorded %d spans, want 1", len(spans))
+		}
+		got := spans[0]
+		if got.Name() != "Login" {
+			t.Errorf("span name = %q, want %q", got.Name(), "Login")
+		}
+		if got.Status().Code.String() != "Error" {
+			t.Errorf("error path should set status Error, got %q",
+				got.Status().Code.String())
+		}
+		if len(got.Events()) == 0 {
+			t.Errorf("RecordError should have added an event; got none")
+		}
+	})
+}
+
+// hasStringAttr returns whether the span carries the given string
+// attribute key=val pair. Avoids pulling attribute.KeyValue equality
+// into every assertion.
+func hasStringAttr(span sdktrace.ReadOnlySpan, key, val string) bool {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key && kv.Value.AsString() == val {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Ticket: [DSN-004b](plan/DSN-004b-service-spans.md) — finishes the OTel chapter (DSN-004 → 004a → 004b). DSN-004 wired otelchi (HTTP) and otelpgx (DB) auto-instrumentation; DSN-004a stitched the AMQP edges onto the same trace. That left the middle of every trace as a flat list of DB query spans, with no signal as to which service operation produced which queries when one request fans out into many DB calls.

This PR adds an `INTERNAL`-kind span at every exported method on `inventory.Service` (9 methods) and `user.Service` (4 methods), named after the method, tagged with the relevant business identifiers (`inventory.sku`, `request_id`, `inventory.reservation_id`, `user.username`, etc.), with errors recorded via `span.RecordError` + `SetStatus(Error)`.

## Helper

`observability.StartServiceSpan(ctx, tracerName, spanName, attrs...)` returns the new ctx and a finisher closure. Callers `defer` the closure with their named-error return:

```go
func (s *service) Reserve(ctx context.Context, rr ReservationRequest) (res Reservation, err error) {
    ctx, end := observability.StartServiceSpan(ctx, tracerName, "Reserve",
        attribute.String("inventory.sku", rr.Sku),
        attribute.String("request_id", rr.RequestID),
    )
    defer func() { end(err) }()
    // ... body unchanged ...
}
```

Named returns make the deferred closure see whatever value the body ends up returning, without a wrapper closure that captures a local `err`.

## Sub-fix: gosec G115 on `GetReservation`

OTel's attribute helpers don't include `Uint64`. The natural `attribute.Int64("inventory.reservation_id", int64(ID))` would overflow at IDs > `MaxInt64` — in practice IDs come from a Postgres sequence so it never trips, but gosec G115 flags the unchecked cast. Using `attribute.String("...", strconv.FormatUint(ID, 10))` sidesteps the conversion entirely; trace UIs render numeric strings fine.

## Tests

`TestUserService_SpansHappyAndError` and `TestInventoryService_SpansHappyAndError` each cover one happy and one error path against the in-memory `tracetest.SpanRecorder`:

- Happy paths assert exactly one span, the right name, no Error status, and the expected business-id attribute.
- Error paths assert exactly one span, Error status, and that `RecordError` emitted an event.

Each package's test file gets its own `withRecordingTracer` helper mirroring the one DSN-004a added in the amqp package — the same shape works everywhere because the OTel provider is global.

## Out of scope (per ticket)

- Spans inside `core/auth` and `core/secrets` — startup-only paths.
- AMQP cross-service propagation — DSN-004a's territory.

## Acceptance criteria

- [x] Every exported method on `inventory.Service` and `user.Service` produces a span.
- [x] Tests verify span creation via `tracetest.InMemoryExporter` (via `SpanRecorder`) for at least one happy and one error path per service.
- [x] No existing test regresses; `make verify` clean.

## Verification

```
$ make verify
==> verify OK

$ go test ./internal/user -run TestUserService_SpansHappyAndError -v
--- PASS: TestUserService_SpansHappyAndError/happy_path:_Get_records_span_without_error (0.00s)
--- PASS: TestUserService_SpansHappyAndError/error_path:_Login_records_error_on_span (0.00s)

$ go test ./internal/inventory -run TestInventoryService_SpansHappyAndError -v
--- PASS: TestInventoryService_SpansHappyAndError/happy_path:_GetProductInventory_records_span_without_error (0.00s)
--- PASS: TestInventoryService_SpansHappyAndError/error_path:_Reserve_validation_failure_records_error (0.00s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)