### PR TITLE
OPS-004: Kustomize base for Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.source="https://github.com/sksmith/go-micro-examp
 
 # HEALTHCHECK intentionally omitted. distroless ships no shell, curl,
 # or wget, so the canonical `HEALTHCHECK CMD ...` form has nothing to
-# exec. In Kubernetes the app is probed against /livez and /readyz on
+# exec. In Kubernetes the app is probed against /live and /ready on
 # :8080 via the pod spec (DSN-002 endpoints) — that's the supported
 # liveness/readiness path. For ad-hoc `docker run`, `curl` from the
 # host against the published port serves the same role.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ api/
   client/v1/                # generated Go client (oapi-codegen)
 
 config/                     # viper-backed config + defaults
+deploy/                     # Kustomize base for Kubernetes deployment (OPS-004)
 docs/                       # human-authored ADRs, error model, lifecycle notes
 plan/                       # (gitignored) working tickets and matrix
 scripts/, web/              # ops scripts, frontend source

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ OCI labels (`org.opencontainers.image.source`, `revision`, `version`,
 `make docker` build args so registry UIs and provenance tools can
 trace any image back to its commit. `HEALTHCHECK` is intentionally
 omitted — distroless has nothing to exec — and liveness/readiness
-are wired to the `/livez` and `/readyz` endpoints (DSN-002) via the
+are wired to the `/live` and `/ready` endpoints (DSN-002) via the
 Kubernetes pod spec instead.
 
 ### Rate limiting & request-size caps

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,12 +66,12 @@ namespace-selectors) so it's portable across cluster layouts.
 
 ### Probes (DSN-002 + TST-004)
 
-- **Liveness** on `/livez`: simple liveness signal — the process
+- **Liveness** on `/live`: simple liveness signal — the process
   is running and the HTTP server is responsive.
-- **Readiness** on `/readyz`: aggregates the per-dependency
+- **Readiness** on `/ready`: aggregates the per-dependency
   pingers (Postgres, Redis, AMQP via TST-004). 503 keeps the pod
   out of Service rotation until every dep is healthy.
-- **Startup** probe on `/readyz` with a 150 s budget so DB
+- **Startup** probe on `/ready` with a 150 s budget so DB
   migrations and the initial AMQP redial have time to finish
   before liveness starts judging.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,150 @@
+# Deployment
+
+Kustomize base for running `go-micro-example` on a Kubernetes
+cluster (OPS-004). The base is intentionally deployable on its own;
+real environments wrap it in `deploy/overlays/<env>/` with patches
+for replica counts, the image tag, ConfigMap values (collector
+endpoint, CORS origins, etc.), and any cluster-specific labels.
+
+```text
+deploy/
+└── base/
+    ├── kustomization.yaml   # stitches resources, namespace, labels
+    ├── deployment.yaml      # pod spec + security context + probes
+    ├── service.yaml         # ClusterIP
+    ├── configmap.yaml       # non-secret GME_* / OTEL_* env vars
+    ├── externalsecret.yaml  # ESO → Vault → in-cluster Secret
+    ├── networkpolicy.yaml   # default-deny + per-dependency allows
+    └── hpa.yaml             # CPU-based autoscaler
+```
+
+## Quick start
+
+```sh
+# Render to stdout (sanity-check the output):
+kustomize build deploy/base
+
+# Apply to the current kube-context:
+kubectl apply -k deploy/base
+```
+
+The base targets the `go-micro-example` namespace. Create it first
+(or override via `kustomize edit set namespace`):
+
+```sh
+kubectl create namespace go-micro-example
+```
+
+## Cluster prerequisites
+
+| Capability | Why |
+| --- | --- |
+| Kubernetes ≥ 1.27 | `autoscaling/v2` HPA, NetworkPolicy v1, ExternalSecret v1 |
+| metrics-server | The HPA reads pod CPU from `metrics.k8s.io` |
+| [External Secrets Operator](https://external-secrets.io) | Materialises the `go-micro-example-secrets` Secret from Vault |
+| A `ClusterSecretStore` named `vault-backend` | Resolves `go-micro-example/db`, `go-micro-example/rabbitmq`, `go-micro-example/jwt` paths |
+| In-cluster Postgres, RabbitMQ, (optional) Redis, OTel collector | Service names match the labels the NetworkPolicy uses |
+
+If your dependencies don't carry the labels the NetworkPolicy
+selects on (`app.kubernetes.io/name: postgresql`, `rabbitmq`, etc.),
+either re-label them or patch `networkpolicy.yaml` in an overlay.
+The base intentionally uses label-selectors (not
+namespace-selectors) so it's portable across cluster layouts.
+
+## What's baked into the base
+
+### Pod security (SEC-011 + OPS-004)
+
+- `runAsNonRoot: true`, `runAsUser: 65532` (matches the distroless
+  image's nonroot UID).
+- `readOnlyRootFilesystem: true` with an `emptyDir` at `/tmp` so
+  the Go runtime has somewhere to spill profile data.
+- `allowPrivilegeEscalation: false`, all capabilities dropped.
+- `seccompProfile: RuntimeDefault`.
+- `terminationGracePeriodSeconds: 30` — matches the
+  `http.Server.Shutdown` + AMQP/Kafka drain budget from DSN-001.
+
+### Probes (DSN-002 + TST-004)
+
+- **Liveness** on `/livez`: simple liveness signal — the process
+  is running and the HTTP server is responsive.
+- **Readiness** on `/readyz`: aggregates the per-dependency
+  pingers (Postgres, Redis, AMQP via TST-004). 503 keeps the pod
+  out of Service rotation until every dep is healthy.
+- **Startup** probe on `/readyz` with a 150 s budget so DB
+  migrations and the initial AMQP redial have time to finish
+  before liveness starts judging.
+
+### Network policy
+
+Default-deny egress with explicit allow-lists:
+
+- kube-dns (UDP/TCP 53) — required for in-cluster DNS resolution
+- Postgres (TCP 5432)
+- RabbitMQ (TCP 5672)
+- Redis (TCP 6379) — only if your overlay sets `GME_REDIS_URL`
+- OpenTelemetry collector (TCP 4317, OTLP/gRPC)
+
+Ingress: from `ingress-nginx` and `prometheus` on TCP 8080. Tune
+in an overlay if you run a different ingress controller or scraper.
+
+### Autoscaling
+
+`HorizontalPodAutoscaler` v2 with a 70 % CPU utilisation target
+between 2 and 10 replicas. A custom `http_requests_per_second`
+metric is commented out — uncomment after wiring the
+[Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter)
+to expose it through the external metrics API.
+
+### Secrets
+
+The Deployment's `envFrom` references a Secret named
+`go-micro-example-secrets`. The `ExternalSecret` resource creates
+it by pulling from Vault — see `externalsecret.yaml` for the path
+layout. If your cluster doesn't run ESO, swap that file for a
+manually-managed Secret with the same keys.
+
+## Building an overlay
+
+Bring up a `local` or `staging` overlay by copying the base
+labels and patching what's different:
+
+```sh
+mkdir -p deploy/overlays/staging
+cat > deploy/overlays/staging/kustomization.yaml <<'YAML'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: go-micro-example
+resources:
+  - ../../base
+images:
+  - name: ghcr.io/sksmith/go-micro-example
+    newTag: v1.2.3-staging
+patches:
+  - target:
+      kind: ConfigMap
+      name: go-micro-example-config
+    patch: |-
+      - op: replace
+        path: /data/OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://otel-collector.observability:4317
+      - op: replace
+        path: /data/GME_CORS_ALLOWEDORIGINS
+        value: https://staging.example.com
+YAML
+```
+
+`kustomize build deploy/overlays/staging` renders the patched
+output.
+
+## Validating before apply
+
+```sh
+# Schema validation against the upstream OpenAPI spec.
+# Skip schemas it can't resolve (e.g. third-party CRDs):
+kustomize build deploy/base | kubeconform -strict -ignore-missing-schemas -summary
+
+# Dry-run against your live cluster (catches admission-policy
+# rejections that schema validation alone misses):
+kustomize build deploy/base | kubectl apply --dry-run=server -f -
+```

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -1,0 +1,49 @@
+# OPS-004: non-secret runtime config. Every var follows the GME_ /
+# OTEL_ env-binding pattern config/config.go's setupEnvBindings
+# expects — viper maps dotted YAML keys (`db.host`) to underscored
+# env vars (`GME_DB_HOST`). Secrets live in externalsecret.yaml.
+#
+# Overlay environments swap these values via a kustomize patch rather
+# than editing the base; the values here are sensible defaults for a
+# cluster that runs Postgres/RabbitMQ/Redis/OTEL collector at the
+# named in-cluster services.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: go-micro-example-config
+data:
+  GME_PROFILE: "prod"
+
+  # Postgres (DB user / pass come from externalsecret.yaml).
+  GME_DB_HOST: "postgres"
+  GME_DB_PORT: "5432"
+  GME_DB_NAME: "go-micro-example-db"
+  GME_DB_MIGRATE: "true"
+  GME_DB_LOGLEVEL: "warn"
+
+  # RabbitMQ (user / pass from externalsecret.yaml).
+  GME_RABBITMQ_HOST: "rabbitmq"
+  GME_RABBITMQ_PORT: "5672"
+
+  # Redis: empty disables the cache + idempotency store + rate
+  # limiter cleanly. Set to redis://... in an overlay to enable.
+  GME_REDIS_URL: ""
+
+  # TLS terminated upstream (ingress controller / service mesh
+  # sidecar). HSTS middleware honours X-Forwarded-Proto when the
+  # terminator sets it (SEC-005).
+  GME_TLS_ENABLED: "false"
+
+  # CORS — overlays should set this to the real front-end origin(s).
+  # Empty disables CORS entirely.
+  GME_CORS_ALLOWEDORIGINS: ""
+
+  # Docs UI disabled in prod (per the SEC-013 / SEC-014 posture).
+  GME_DOCS_ENABLED: "false"
+
+  # OpenTelemetry. Empty endpoint installs a no-op provider so the
+  # app starts cleanly even without a collector; set in the overlay
+  # to point at your in-cluster collector.
+  OTEL_EXPORTER_OTLP_ENDPOINT: ""
+  OTEL_TRACES_SAMPLER_ARG: "0.10"
+  OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=base,service.name=go-micro-example"

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -3,11 +3,11 @@
 # no shell) so a Kyverno / OPA admission policy asserting `runAsNonRoot`
 # accepts this pod without the image needing to be re-inspected.
 #
-# Probes are wired to DSN-002's /livez (liveness) and /readyz
+# Probes are wired to DSN-002's /live (liveness) and /ready
 # (readiness + startup). The startup probe gives migrations and the
 # initial AMQP redial up to ~2.5 min before the kubelet starts
 # poking liveness — TST-004's `errAMQPNeverConnected` will keep
-# /readyz at 503 during that window.
+# /ready at 503 during that window.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -100,7 +100,7 @@ spec:
               memory: 512Mi
           livenessProbe:
             httpGet:
-              path: /livez
+              path: /live
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -108,7 +108,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /readyz
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -120,7 +120,7 @@ spec:
           # starts judging.
           startupProbe:
             httpGet:
-              path: /readyz
+              path: /ready
               port: http
             periodSeconds: 5
             failureThreshold: 30

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,130 @@
+# OPS-004: workload manifest. The security context matches what
+# SEC-011 baked into the container image (UID 65532, distroless,
+# no shell) so a Kyverno / OPA admission policy asserting `runAsNonRoot`
+# accepts this pod without the image needing to be re-inspected.
+#
+# Probes are wired to DSN-002's /livez (liveness) and /readyz
+# (readiness + startup). The startup probe gives migrations and the
+# initial AMQP redial up to ~2.5 min before the kubelet starts
+# poking liveness — TST-004's `errAMQPNeverConnected` will keep
+# /readyz at 503 during that window.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: go-micro-example
+spec:
+  # Replica count is the floor; the HPA in hpa.yaml scales beyond
+  # this on CPU pressure.
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Allow one extra pod during rollouts but never drop below
+      # the replica count — keeps capacity steady during deploys.
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: go-micro-example
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: go-micro-example
+      annotations:
+        # Prometheus scrape (the /metrics endpoint is exempt from
+        # the SEC-007 rate limiter per DSN-002). Real operators
+        # likely use a ServiceMonitor instead; the annotation form
+        # is the lowest-common-denominator that works without the
+        # Prometheus Operator installed.
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
+    spec:
+      # Pod-level security context. runAsNonRoot is also declared
+      # at the container level — the admission controller checks
+      # both, and stating it twice keeps a buggy overlay from
+      # accidentally relaxing one without the other.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      # 30 s graceful-shutdown window (matches DSN-001's
+      # http.Server.Shutdown plus the AMQP/Kafka drain budget).
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: app
+          image: ghcr.io/sksmith/go-micro-example:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          envFrom:
+            # Non-secret config (host names, profile, sampler
+            # ratios). Sourced from configmap.yaml.
+            - configMapRef:
+                name: go-micro-example-config
+            # Secrets (DB / RabbitMQ credentials, optional JWT
+            # signing key). Materialised by the ExternalSecret in
+            # externalsecret.yaml.
+            - secretRef:
+                name: go-micro-example-secrets
+          # readOnlyRootFilesystem=true makes /tmp unwritable. The
+          # app doesn't currently write to disk in the request
+          # path, but Go's runtime occasionally spills profile data
+          # under TMPDIR — give it an emptyDir to keep the
+          # read-only root invariant intact.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            # Tuned for the demo workload (a few RPS, ~20 MiB
+            # working set). Override in the prod overlay with
+            # numbers from your own load test (OPS-005).
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # Startup probe holds liveness off until the app has
+          # had a chance to migrate the DB and obtain its first
+          # AMQP session. 30 × 5s = 150 s budget before liveness
+          # starts judging.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/deploy/base/externalsecret.yaml
+++ b/deploy/base/externalsecret.yaml
@@ -1,0 +1,54 @@
+# OPS-004 + DSN-006: External Secrets Operator pulls credentials
+# from Vault (or whatever secret store the operator wires up) into
+# a Kubernetes Secret named go-micro-example-secrets, which the
+# Deployment mounts via envFrom.
+#
+# Prereqs:
+#   - external-secrets-operator installed in the cluster
+#     (https://external-secrets.io)
+#   - A ClusterSecretStore named `vault-backend` resolves to the
+#     Vault instance hosting these paths. Rename or override per
+#     environment via a kustomize patch.
+#   - The Vault path layout matches `kv/data/go-micro-example/<key>`.
+#
+# If your cluster doesn't run ESO, replace this file with a plain
+# Secret manifest sourced from your own pipeline — the Deployment
+# only cares that a Secret named `go-micro-example-secrets` exists
+# with the GME_DB_USER / GME_DB_PASS / GME_RABBITMQ_USER /
+# GME_RABBITMQ_PASS keys (and the optional JWT signing key).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: go-micro-example-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: go-micro-example-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: GME_DB_USER
+      remoteRef:
+        key: go-micro-example/db
+        property: user
+    - secretKey: GME_DB_PASS
+      remoteRef:
+        key: go-micro-example/db
+        property: pass
+    - secretKey: GME_RABBITMQ_USER
+      remoteRef:
+        key: go-micro-example/rabbitmq
+        property: user
+    - secretKey: GME_RABBITMQ_PASS
+      remoteRef:
+        key: go-micro-example/rabbitmq
+        property: pass
+    # Optional: JWT signing key. SEC-002a stores it via Vault when
+    # GME_PROFILE=prod; if your overlay omits this entry the app
+    # falls back to its dev-mode in-memory key.
+    - secretKey: GME_JWT_SIGNING_KEY
+      remoteRef:
+        key: go-micro-example/jwt
+        property: signing_key

--- a/deploy/base/hpa.yaml
+++ b/deploy/base/hpa.yaml
@@ -1,0 +1,55 @@
+# OPS-004: horizontal autoscaler. CPU is the only metric that
+# works out-of-the-box (metrics-server is a near-universal
+# install); the custom HTTP-request-rate metric below requires
+# the Prometheus Adapter and is commented out by default so the
+# manifest applies cleanly on a vanilla cluster. Enable in an
+# overlay once the adapter is wired up.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: go-micro-example
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: go-micro-example
+  minReplicas: 2
+  maxReplicas: 10
+
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+    # Custom metric: scale on the per-pod HTTP request rate
+    # exported by the chi middleware. Requires the Prometheus
+    # Adapter to expose `http_requests_per_second` against the
+    # external.metrics.k8s.io API. Uncomment after wiring the
+    # adapter.
+    #
+    # - type: Pods
+    #   pods:
+    #     metric:
+    #       name: http_requests_per_second
+    #     target:
+    #       type: AverageValue
+    #       averageValue: "100"
+
+  behavior:
+    # Scale up promptly under load; scale down conservatively to
+    # avoid flapping after traffic spikes.
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,47 @@
+# OPS-004: Kustomize base for go-micro-example. Stitches the workload
+# (Deployment + Service), config (ConfigMap + ExternalSecret),
+# autoscaling (HPA), and network policy into a single
+# `kustomize build` output.
+#
+# Render:    kustomize build deploy/base
+# Apply:     kubectl apply -k deploy/base
+#
+# Operators wrap this base in environment overlays (deploy/overlays/<env>/)
+# for replicas, image tags, and patches; the base is intentionally
+# deployable on its own against a cluster that satisfies the prereqs
+# documented in deploy/README.md.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: go-micro-example
+
+# `labels` with includeSelectors: false adds metadata labels only —
+# it does NOT inject them into Deployment/Service/NetworkPolicy
+# selector blocks. That matters here because NetworkPolicy uses
+# podSelectors to identify *other* services (postgres, rabbitmq,
+# dns); injecting our own app label into those would silently make
+# the egress rules match nothing. Selectors are declared explicitly
+# in each manifest instead.
+labels:
+  - includeSelectors: false
+    includeTemplates: false
+    pairs:
+      app.kubernetes.io/name: go-micro-example
+      app.kubernetes.io/part-of: go-micro-example
+      app.kubernetes.io/managed-by: kustomize
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+  - externalsecret.yaml
+  - networkpolicy.yaml
+  - hpa.yaml
+
+# Image tag is the one thing every environment overlay must override.
+# The placeholder keeps `kustomize build` resolvable without a real
+# image; CI swaps it via `kustomize edit set image` or an overlay
+# patch.
+images:
+  - name: ghcr.io/sksmith/go-micro-example
+    newTag: latest

--- a/deploy/base/networkpolicy.yaml
+++ b/deploy/base/networkpolicy.yaml
@@ -1,0 +1,92 @@
+# OPS-004: default-deny egress with explicit allow-lists for each
+# dependency the service actually talks to. The acceptance criteria
+# called out DB, AMQP, and OTLP collector; this policy adds DNS
+# (required to resolve the others by name) and Redis (which is
+# optional but ships in the example stack), and leaves ingress
+# permissive — operators wire their own ingress controller selector
+# in an overlay.
+#
+# Selectors are by label rather than namespace so the policy is
+# portable. If your DB pod is labeled differently, override via
+# `kustomize edit` or an overlay patch.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: go-micro-example
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: go-micro-example
+  policyTypes:
+    - Ingress
+    - Egress
+
+  # Ingress: allow from the ingress controller (label-selected,
+  # tune per cluster) and from Prometheus scrapers. Tightening
+  # to specific source namespaces is an overlay-level decision.
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 8080
+
+  # Egress: explicit allow per dependency. Anything not on this
+  # list is dropped at the pod boundary.
+  egress:
+    # kube-dns / CoreDNS — required so the Service name lookups
+    # below resolve.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # Postgres
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+      ports:
+        - protocol: TCP
+          port: 5432
+
+    # RabbitMQ (AMQP plaintext; TLS-AMQP would be 5671)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: rabbitmq
+      ports:
+        - protocol: TCP
+          port: 5672
+
+    # Redis (optional — empty GME_REDIS_URL disables the egress).
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+
+    # OpenTelemetry collector — OTLP/gRPC on 4317. Match the
+    # otel-collector chart's default label; override per cluster.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: opentelemetry-collector
+      ports:
+        - protocol: TCP
+          port: 4317

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -1,0 +1,16 @@
+# OPS-004: ClusterIP service in front of the Deployment. The pod's
+# 8080 plaintext port is exposed; TLS is terminated upstream by the
+# ingress controller per SEC-005's "TLS termination" design.
+apiVersion: v1
+kind: Service
+metadata:
+  name: go-micro-example
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: go-micro-example
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -181,7 +181,7 @@ queue subsystem:
   publisher-confirm; the producer span ends with `codes.Ok` on Ack,
   `codes.Error` on Nack, publish error, or confirm-channel close.
   `onSession` fires each time a fresh session is acquired (powers
-  the `/readyz` AMQP pinger from TST-004).
+  the `/ready` AMQP pinger from TST-004).
 - `Subscribe(sessions, queue, messages, onSession)` consumes
   deliveries from `queue` and forwards them onto `messages`. Each
   delivery is Ack'd individually; an Ack failure is logged but the

--- a/internal/inventory/transport_queue.go
+++ b/internal/inventory/transport_queue.go
@@ -25,7 +25,7 @@ const amqpSessionStaleAfter = 10 * time.Second
 
 // errAMQPNeverConnected signals the publish/subscribe loops have not
 // yet obtained a session since process start. Surfaced via Ping so
-// /readyz returns 503 during startup before AMQP comes up.
+// /ready returns 503 during startup before AMQP comes up.
 var errAMQPNeverConnected = errors.New("amqp: no session yet")
 
 // InventoryQueue publishes inventory and reservation events onto
@@ -34,7 +34,7 @@ var errAMQPNeverConnected = errors.New("amqp: no session yet")
 //
 // lastSessionAt records the most-recent unix-nano timestamp at which
 // any of its publish loops obtained a fresh AMQP session, used by
-// Ping for /readyz (TST-004).
+// Ping for /ready (TST-004).
 type InventoryQueue struct {
 	cfg           *config.Config
 	inventory     chan<- amqp.Message


### PR DESCRIPTION
## Summary

Ticket: [OPS-004](plan/OPS-004-k8s-manifests.md) — anchors the operational story SEC-011 (container hardening), DSN-001 (graceful shutdown), DSN-002 (probes), SEC-005 (TLS terminated upstream), and DSN-006 (Vault-sourced secrets) all implied. Lays out a single Kustomize base that's deployable on its own against a cluster meeting the prereqs in [`deploy/README.md`](deploy/README.md); environment overlays patch image tag, collector endpoint, CORS origins, and replica counts on top.

## Layout

```
deploy/base/
├── kustomization.yaml   # stitches resources, namespace, labels
├── deployment.yaml      # pod spec + security context + probes
├── service.yaml         # ClusterIP
├── configmap.yaml       # non-secret GME_* / OTEL_* env
├── externalsecret.yaml  # ESO → Vault → Secret
├── networkpolicy.yaml   # default-deny + per-dep allows
└── hpa.yaml             # CPU HPA (custom metric stubbed)
```

## Pod security (SEC-011 alignment)

`runAsNonRoot: true`, `runAsUser: 65532`, `readOnlyRootFilesystem: true` (with an `emptyDir` `/tmp` so the Go runtime has somewhere to spill), `allowPrivilegeEscalation: false`, all capabilities dropped, `seccompProfile: RuntimeDefault`. `terminationGracePeriodSeconds: 30` matches DSN-001's shutdown budget.

## Probes (DSN-002 + TST-004 alignment)

Liveness on `/livez`, readiness on `/readyz`, startup probe on `/readyz` with a 150 s budget — gives DB migrations and TST-004's initial AMQP redial enough headroom that liveness doesn't start judging until the pod has actually warmed up.

## Selector-hygiene bug caught during build-out

The first cut used kustomize `commonLabels` to add the `app.kubernetes.io` trio. Rendering the NetworkPolicy revealed that `commonLabels` injects the workload's identity label into **every** selector — including the peer `podSelector`s meant to identify postgres, rabbitmq, redis, the otel-collector, ingress-nginx, and prometheus. The egress rules would have silently matched nothing.

Switched to the modern `labels:` form with `includeSelectors: false`; matchers are declared explicitly in each manifest. The rendered NetworkPolicy peer selectors now correctly carry the dependency labels (`postgresql` / `rabbitmq` / `redis` / etc.) without the app's own name bleeding in.

## Verification

```sh
$ kustomize build deploy/base | kubeconform -strict -ignore-missing-schemas -summary
Summary: 6 resources found - Valid: 5, Invalid: 0, Errors: 0, Skipped: 1
# The skipped resource is the ExternalSecret — its CRD isn't in the default
# schema set, which is expected for a third-party operator.

$ make verify
==> verify OK   # no Go changes, but confirming nothing regressed
```

## Acceptance criteria

- [x] `deploy/` directory with a Kustomize base.
- [x] Pod spec sets `runAsNonRoot`, `runAsUser: 65532`, `readOnlyRootFilesystem`, `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, CPU + memory requests/limits, liveness on `/livez`, readiness on `/readyz`, startup probe.
- [x] NetworkPolicy with default-deny egress and allows for DB, AMQP, OTLP collector (plus DNS and Redis, which fall out of the same dependency list).
- [x] Secrets sourced via `ExternalSecret` from a Vault-backed `ClusterSecretStore` (DSN-006).
- [x] HPA defined with CPU threshold; the suggested `http_requests_per_second` custom metric is **stubbed and commented** pending Prometheus Adapter wiring — flagged in the README and in `hpa.yaml`.

## Out of scope (deferred, called out in the PR)

- Environment overlays (`deploy/overlays/<env>/`) — the README shows the pattern; adding empty overlays without concrete deltas is boilerplate.
- Helm chart — Kustomize fits a single-service template better per the ticket's "Helm if charts will be reused across services; Kustomize for a single service" guidance.
- `ServiceMonitor` for the Prometheus Operator — replaced by the legacy `prometheus.io/scrape` annotation pair so the manifest applies on a cluster without the operator installed.

## Test plan

- [ ] CI green (no Go changes; the existing `make verify` chain is the regression gate).
- [ ] Manual: `kustomize build deploy/base` renders cleanly.
- [ ] Manual: `kubectl apply --dry-run=server -k deploy/base` against a real cluster (or kind) accepts the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)