### PR TITLE
K8S-001: local kind cluster + dry-run validation gate

### DIFF
--- a/.github/workflows/k8s-validate.yml
+++ b/.github/workflows/k8s-validate.yml
@@ -1,0 +1,31 @@
+# K8S-001: Tier 1 dry-run validation gate. Stands a kind cluster up
+# and runs `make k8s-validate` so admission/RBAC/label issues in the
+# OPS-004 base (and any future overlay) are caught before merge.
+#
+# Path-filtered to `deploy/**` plus this workflow so it doesn't run
+# on PRs that don't touch the manifests.
+name: k8s-validate
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'deploy/**'
+      - '.github/workflows/k8s-validate.yml'
+permissions:
+  contents: read
+jobs:
+  validate:
+    name: kind dry-run apply
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create kind cluster
+        # helm/kind-action v1.14.0 — pinned by commit SHA so a tag
+        # repoint can't silently change what runs in CI.
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc
+        with:
+          cluster_name: go-micro-example
+          config: deploy/kind/cluster.yaml
+      - name: Dry-run apply
+        run: make k8s-validate

--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,37 @@ demo:
 
 demo-down:
 	docker compose down -v
+
+# K8S-001: Local kind cluster + dry-run validation gate.
+#
+# `k8s-up` stands up a single-node kind cluster pinned to the kube
+# version the OPS-004 base targets. `k8s-validate` renders the
+# Kustomize base and dry-run-applies it against the live apiserver,
+# catching admission/RBAC/label bugs that offline schema validation
+# (kubeconform) cannot. `k8s-down` tears the cluster back down.
+#
+# `ExternalSecret` is filtered before the dry-run because the
+# external-secrets.io CRDs are not installed in this Tier 1 cluster
+# (the operator install is K8S-005's territory). When K8S-005 lands,
+# drop the yq filter so the dry-run covers the full base.
+#
+# Prereqs (local): kind, kubectl, yq. See deploy/README.md for
+# install hints. CI installs them via helm/kind-action and the
+# default ubuntu-latest tooling.
+.PHONY: k8s-up k8s-down k8s-validate
+KIND_CLUSTER ?= go-micro-example
+KIND_CONFIG  ?= deploy/kind/cluster.yaml
+
+k8s-up:
+	@command -v kind >/dev/null 2>&1 || { echo "kind not found. Install via 'brew install kind' (macOS) or see https://kind.sigs.k8s.io/docs/user/quick-start/#installation."; exit 1; }
+	kind create cluster --name $(KIND_CLUSTER) --config $(KIND_CONFIG)
+
+k8s-down:
+	@command -v kind >/dev/null 2>&1 || { echo "kind not found."; exit 1; }
+	kind delete cluster --name $(KIND_CLUSTER)
+
+k8s-validate:
+	@command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found."; exit 1; }
+	@command -v yq >/dev/null 2>&1 || { echo "yq not found. Install via 'brew install yq' (macOS) or see https://github.com/mikefarah/yq#install."; exit 1; }
+	@kubectl get namespace go-micro-example >/dev/null 2>&1 || kubectl create namespace go-micro-example
+	kubectl kustomize deploy/base | yq 'select(.kind != "ExternalSecret")' | kubectl apply --dry-run=server -f -

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,14 +8,16 @@ endpoint, CORS origins, etc.), and any cluster-specific labels.
 
 ```text
 deploy/
-└── base/
-    ├── kustomization.yaml   # stitches resources, namespace, labels
-    ├── deployment.yaml      # pod spec + security context + probes
-    ├── service.yaml         # ClusterIP
-    ├── configmap.yaml       # non-secret GME_* / OTEL_* env vars
-    ├── externalsecret.yaml  # ESO → Vault → in-cluster Secret
-    ├── networkpolicy.yaml   # default-deny + per-dependency allows
-    └── hpa.yaml             # CPU-based autoscaler
+├── base/
+│   ├── kustomization.yaml   # stitches resources, namespace, labels
+│   ├── deployment.yaml      # pod spec + security context + probes
+│   ├── service.yaml         # ClusterIP
+│   ├── configmap.yaml       # non-secret GME_* / OTEL_* env vars
+│   ├── externalsecret.yaml  # ESO → Vault → in-cluster Secret
+│   ├── networkpolicy.yaml   # default-deny + per-dependency allows
+│   └── hpa.yaml             # CPU-based autoscaler
+└── kind/
+    └── cluster.yaml         # K8S-001 local Tier 1 validation gate
 ```
 
 ## Quick start
@@ -148,3 +150,35 @@ kustomize build deploy/base | kubeconform -strict -ignore-missing-schemas -summa
 # rejections that schema validation alone misses):
 kustomize build deploy/base | kubectl apply --dry-run=server -f -
 ```
+
+### Local Tier 1 validation against a real apiserver (K8S-001)
+
+`kubeconform` validates schemas offline. To also exercise the
+apiserver's admission path — admission controllers, RBAC, label
+selector mismatches, kustomize/apiserver drift — stand up a local
+[`kind`](https://kind.sigs.k8s.io/) cluster and dry-run-apply the
+base against it:
+
+```sh
+make k8s-up         # creates a single-node kind cluster pinned to
+                    # the kube version in deploy/kind/cluster.yaml
+make k8s-validate   # renders the base, filters ExternalSecret, and
+                    # `kubectl apply --dry-run=server`s the rest
+make k8s-down       # tears the cluster down
+```
+
+`make k8s-validate` filters out the `ExternalSecret` resource
+because the external-secrets.io CRDs are not installed in this
+Tier 1 cluster — K8S-005 wires External Secrets Operator and
+removes the filter. Everything else in the base goes through the
+apiserver unchanged.
+
+**Local prereqs:** `kind`, `kubectl`, and
+[`yq`](https://github.com/mikefarah/yq) on `PATH`. The make targets
+print an install hint if any of them is missing.
+
+CI runs the same gate via `.github/workflows/k8s-validate.yml`,
+path-filtered to PRs that touch `deploy/**`. It uses
+[`helm/kind-action`](https://github.com/helm/kind-action) (pinned
+by commit SHA) to provision the cluster, then invokes
+`make k8s-validate`.

--- a/deploy/kind/cluster.yaml
+++ b/deploy/kind/cluster.yaml
@@ -1,0 +1,16 @@
+# K8S-001: kind cluster config for the local Tier 1 validation gate.
+#
+# Single-node control-plane is enough to exercise the apiserver's
+# admission/validation path against the OPS-004 base. No worker
+# nodes — Tier 2 (K8S-002/003) is the layer that actually runs pods.
+#
+# The node image is pinned by digest so every developer machine and
+# CI runner exercises the exact same Kubernetes build. Bump
+# intentionally when the upstream kind release publishes a new image;
+# the digests live in https://github.com/kubernetes-sigs/kind/releases.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: go-micro-example
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b


### PR DESCRIPTION
Closes [K8S-001](plan/K8S-001-local-kind-cluster.md) — Tier 1 of the local-k8s ladder (schema + admission validation against a real apiserver).

## Summary

- `deploy/kind/cluster.yaml` — single-node kind cluster pinned to `kindest/node:v1.31.14` (digest-pinned for reproducibility).
- Makefile targets `k8s-up` / `k8s-validate` / `k8s-down` that create the cluster, dry-run-apply the OPS-004 base against it, and tear it down.
- `.github/workflows/k8s-validate.yml` runs the same gate on PRs touching `deploy/**`, using `helm/kind-action` pinned by commit SHA (`ef37e7f`, v1.14.0).
- `deploy/README.md` documents both the local and CI flow.

The validate pipeline renders the base with `kubectl kustomize`, filters out the `ExternalSecret` resource (the external-secrets.io CRDs are not installed in this tier — K8S-005 reintroduces them), then dry-run-applies the rest with `kubectl apply --dry-run=server`.

## Acceptance criteria

- [x] `make k8s-up && make k8s-validate && make k8s-down` exits 0 against the OPS-004 base.
- [x] CI runs the validate gate on every PR touching `deploy/**` and blocks merge on failure.
- [x] `deploy/README.md` documents both the local and CI flow.

## Local verification

```
$ make k8s-up
kind create cluster --name go-micro-example --config deploy/kind/cluster.yaml
 ✓ Ensuring node image (kindest/node:v1.31.14) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾

$ make k8s-validate
namespace/go-micro-example created
configmap/go-micro-example-config created (server dry run)
service/go-micro-example created (server dry run)
deployment.apps/go-micro-example created (server dry run)
horizontalpodautoscaler.autoscaling/go-micro-example created (server dry run)
networkpolicy.networking.k8s.io/go-micro-example created (server dry run)

$ make k8s-down
Deleting cluster "go-micro-example" ...
Deleted nodes: ["go-micro-example-control-plane"]
```

`make verify` is green.

## New dependencies

- **`kind`** (Kubernetes-in-Docker) — local-only developer tool, install via `brew install kind`.
- **`yq`** (Mike Farah's) — local-only, install via `brew install yq`. Pre-installed on `ubuntu-latest` runners.
- **`helm/kind-action@v1.14.0`** — CI action, pinned by commit SHA (`ef37e7f`).

The make targets print install hints if a prereq is missing.

## Out of scope (follow-up tickets)

- K8S-002 — local overlay + image-load workflow.
- K8S-003 — local dependencies (Postgres / RabbitMQ + plain Secret overlay).
- K8S-004 / K8S-005 / K8S-006 — operator-dependent tiers (HPA scaling, ESO + Vault, OTel collector). K8S-005 also removes the ExternalSecret yq filter once the CRDs are installed.

## Test plan

- [x] `make k8s-up && make k8s-validate && make k8s-down` exits 0 locally.
- [x] `make verify` passes locally.
- [ ] CI: `k8s-validate` workflow runs on this PR and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)