### PR TITLE
K8S-003: in-cluster Postgres / RabbitMQ + plain Secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,11 @@ k8s-validate:
 	@command -v kubectl >/dev/null 2>&1 || { echo "kubectl not found."; exit 1; }
 	@command -v yq >/dev/null 2>&1 || { echo "yq not found. Install via 'brew install yq' (macOS) or see https://github.com/mikefarah/yq#install."; exit 1; }
 	@kubectl get namespace go-micro-example >/dev/null 2>&1 || kubectl create namespace go-micro-example
-	kubectl kustomize $(KUSTOMIZE_DIR) | yq 'select(.kind != "ExternalSecret")' | kubectl apply --dry-run=server -f -
+	# --load-restrictor=LoadRestrictionsNone: the K8S-003 overlay's
+	# configMapGenerator reads scripts/rabbitmq/* from outside its
+	# own directory (shared source of truth with docker-compose).
+	# Harmless for base (which stays inside deploy/base/).
+	kubectl kustomize --load-restrictor=LoadRestrictionsNone $(KUSTOMIZE_DIR) | yq 'select(.kind != "ExternalSecret")' | kubectl apply --dry-run=server -f -
 
 k8s-validate-local:
 	$(MAKE) k8s-validate KUSTOMIZE_DIR=deploy/overlays/local
@@ -185,9 +189,22 @@ k8s-validate-local:
 # K8S-002: build the app image with the dev tag and load it into the
 # kind node's containerd store. The overlay's `imagePullPolicy: Never`
 # tells the kubelet to use this image directly — no registry round-trip.
-# The pod will still CrashLoopBackOff until K8S-003 lands the in-cluster
-# DB / AMQP; what `docker-load` proves is that the image lands where
-# the kubelet expects it.
 docker-load: docker
 	@command -v kind >/dev/null 2>&1 || { echo "kind not found."; exit 1; }
 	kind load docker-image $(IMG_NAME):$(IMG_TAG) --name $(KIND_CLUSTER)
+
+# K8S-003: full local stack — kind cluster + image load + the local
+# overlay (in-cluster Postgres / RabbitMQ + dev Secret). `rollout
+# status` blocks until the app Deployment is Available, which (via
+# the readiness probe) means migrations completed and AMQP redial
+# succeeded. The 300 s timeout covers the 150 s startup-probe budget
+# from DSN-002 plus a margin for image-pull and DB init on a cold
+# kind cluster.
+.PHONY: k8s-local-up k8s-local-down
+k8s-local-up: k8s-up docker-load
+	kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local | kubectl apply -f -
+	kubectl -n go-micro-example rollout status deploy/go-micro-example --timeout=300s
+
+k8s-local-down:
+	-kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local | kubectl delete --ignore-not-found -f -
+	$(MAKE) k8s-down

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,7 +18,11 @@ deploy/
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
 │   └── local/
-│       └── kustomization.yaml  # K8S-002 dev image + Never pull policy
+│       ├── kustomization.yaml  # K8S-002/003 overlay (image + deps)
+│       ├── namespace.yaml      # K8S-003 self-contained namespace
+│       ├── secret.yaml         # K8S-003 plain dev Secret
+│       ├── postgres.yaml       # K8S-003 in-cluster Postgres
+│       └── rabbitmq.yaml       # K8S-003 in-cluster RabbitMQ
 └── kind/
     └── cluster.yaml         # K8S-001 local Tier 1 validation gate
 ```
@@ -186,45 +190,76 @@ path-filtered to PRs that touch `deploy/**`. It uses
 by commit SHA) to provision the cluster, then invokes both
 `make k8s-validate` (base) and `make k8s-validate-local` (overlay).
 
-### Run a real pod locally (K8S-002)
+### Run a Ready pod locally (K8S-002 + K8S-003)
 
-The base manifest references `ghcr.io/sksmith/go-micro-example:latest`,
-an image that won't exist until OPS-007 wires goreleaser. To exercise
-the manifest against the kind cluster *now*, the local overlay swaps
-the reference for a locally-built `go-micro-example:dev` tag and sets
-`imagePullPolicy: Never` so the kubelet uses kind's containerd store
-directly.
+The local overlay (`deploy/overlays/local`) layers four things on
+top of the base:
 
-```sh
-make k8s-up         # K8S-001 cluster
-make docker-load    # `make docker IMG_TAG=dev` + `kind load docker-image`
-kubectl apply -k deploy/overlays/local
-```
+- An image rewrite + `imagePullPolicy: Never` so the kubelet uses a
+  locally-built `go-micro-example:dev` image (K8S-002).
+- A `$patch: delete` that strips the base `ExternalSecret` — the
+  external-secrets.io CRDs aren't installed at this tier (K8S-005's
+  territory), and the overlay supplies a plain `Secret` of the same
+  name instead.
+- A plain `Secret` (`go-micro-example-secrets`) carrying the dev
+  credentials the Deployment's `envFrom` expects (matches the
+  docker-compose defaults).
+- In-cluster `postgres` and `rabbitmq` Deployments + Services with
+  the `app.kubernetes.io/name` labels the base NetworkPolicy
+  selects on. RabbitMQ loads its exchanges/queues/bindings from
+  `scripts/rabbitmq/definitions.json` via a kustomize-generated
+  ConfigMap, so the DSN-015 topology is in place on first boot.
 
-The pod will reach the kubelet, pull the local image cleanly (no
-`ErrImagePull`), and then stall in `CreateContainerConfigError` —
-the base Deployment's `envFrom` references a Secret named
-`go-micro-example-secrets` that the overlay does not yet provide
-(K8S-003 lands the plain Secret + in-cluster Postgres / RabbitMQ in
-the same overlay). What this proves at the K8S-002 step is that the
-image makes it onto the node, the `imagePullPolicy: Never` patch
-applied, and the manifest is otherwise sound. The overlay also
-deletes the base `ExternalSecret` via `$patch: delete`, so the apply
-doesn't trip over the external-secrets.io CRDs being absent
-(K8S-005's territory).
-
-Verify the image rewrite landed and the kubelet did not try to pull
-from a registry:
+One-shot bring-up and tear-down:
 
 ```sh
-kubectl -n go-micro-example describe pod -l app.kubernetes.io/name=go-micro-example \
-  | grep -E 'Image:|Pull Policy:'
-# Image:           go-micro-example:dev
-# Pull Policy:     Never
-
-kubectl -n go-micro-example get events --field-selector=type=Warning \
-  | grep -E 'ErrImagePull|ImagePullBackOff' || echo 'no image-pull errors'
+make k8s-local-up    # k8s-up + docker-load + apply + rollout status
+make k8s-local-down  # delete overlay + k8s-down
 ```
+
+`k8s-local-up` blocks on `kubectl rollout status` until the app
+Deployment is Available, which (via the readiness probe in
+DSN-002 + TST-004) means migrations completed and AMQP redial
+succeeded.
+
+Verify the dependencies are up and the app talked to both of them:
+
+```sh
+kubectl -n go-micro-example get pods
+# go-micro-example-…  …/1   Running   # see TST-005 below for /1 caveat
+# postgres-…          1/1   Running
+# rabbitmq-…          1/1   Running
+
+kubectl -n go-micro-example logs deploy/go-micro-example \
+  | grep -E 'executing migrations|ready to publish messages|listening'
+# INF executing migrations
+# DBG ready to publish messages exchange=inventory.exchange
+# DBG ready to publish messages exchange=reservation.exchange
+# INF listening port=8080
+# INF listening for messages queue=product.queue
+# DBG ready to publish messages exchange=product.dlt.exchange
+```
+
+The "executing migrations" log proves the Postgres egress allow-list
+works (pgx connected via Service name `postgres`), and the "ready to
+publish messages" lines prove the RabbitMQ allow-list works (AMQP
+session established via Service name `rabbitmq`). NetworkPolicy
+enforcement is intrinsic: if the egress rules were wrong, neither
+side would connect.
+
+The pod image is also distroless (no shell), so the conventional
+`kubectl exec … sh -c '…'` connectivity probe doesn't apply here —
+the log evidence above is the substitute.
+
+> **TST-005 caveat.** After the first ~10 s, `/ready` flips to 503
+> because the AMQP staleness check at
+> `internal/inventory/transport_queue.go` doesn't refresh on a
+> healthy long-lived session — `sessionOK()` only fires on
+> (re)connect. The pod still serves traffic; readiness probes will
+> mark it NotReady and Service rotation will drop it. Track in
+> [TST-005](../plan/TST-005-amqp-readiness-stable-session.md);
+> until it's fixed, `make k8s-local-up`'s `kubectl rollout status`
+> succeeds on the initial roll but the pod won't *stay* Ready.
 
 `make k8s-validate-local` runs the dry-run-apply against the overlay
 without needing the image — useful in CI and for sanity-checking

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -11,8 +11,36 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# The base's `namespace:` directive only applies to resources
+# declared in the base itself. Re-declaring it here injects the
+# same namespace into the overlay's new resources (postgres,
+# rabbitmq, the plain Secret, and the generated rabbitmq-definitions
+# ConfigMap) so they land alongside the app instead of defaulting
+# to `default`. The Namespace resource itself is cluster-scoped and
+# is unaffected.
+namespace: go-micro-example
+
 resources:
   - ../../base
+  # K8S-003: in-cluster dependencies. Replace the cluster's "real"
+  # Postgres / RabbitMQ / ExternalSecret with dev-only manifests so
+  # the overlay produces a Ready pod without any operator install.
+  - namespace.yaml
+  - secret.yaml
+  - postgres.yaml
+  - rabbitmq.yaml
+
+# RabbitMQ loads its exchanges/queues/bindings from
+# scripts/rabbitmq/definitions.json on boot (DSN-015). Mounting the
+# files via a kustomize-generated ConfigMap keeps a single source of
+# truth between the docker-compose stack and this overlay; the
+# content-hash suffix kustomize appends to the ConfigMap name means
+# editing definitions triggers a rolling restart automatically.
+configMapGenerator:
+  - name: rabbitmq-definitions
+    files:
+      - ../../../scripts/rabbitmq/definitions.json
+      - ../../../scripts/rabbitmq/rabbitmq.conf
 
 # The base pod references `ghcr.io/sksmith/go-micro-example:latest`.
 # Kustomize matches on the original name and rewrites both the

--- a/deploy/overlays/local/namespace.yaml
+++ b/deploy/overlays/local/namespace.yaml
@@ -1,0 +1,10 @@
+# K8S-003: declare the namespace as part of the overlay so
+# `kubectl apply -k deploy/overlays/local` is self-contained — no
+# `kubectl create namespace` precondition. The base's
+# `namespace: go-micro-example` directive places every namespaced
+# resource here; this manifest just ensures the namespace itself
+# exists in the cluster.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-micro-example

--- a/deploy/overlays/local/postgres.yaml
+++ b/deploy/overlays/local/postgres.yaml
@@ -1,0 +1,89 @@
+# K8S-003: in-cluster Postgres for the local overlay. The base
+# Deployment connects to host `postgres:5432` (from the base
+# ConfigMap), so this Service name must stay `postgres` for the
+# label/host wiring to match without an additional patch. The pod's
+# `app.kubernetes.io/name: postgresql` label matches the base
+# NetworkPolicy egress allow-list.
+#
+# Single replica is fine for local; the PVC binds to kind's
+# `standard` (rancher.io/local-path) storage class, so the data dies
+# with the cluster — desired for hermetic test loops.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app.kubernetes.io/name: postgresql
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+  strategy:
+    # Recreate avoids two Postgres pods racing for the same PVC
+    # during a rollout (RWO volume can only attach to one node).
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgresql
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            # Match docker-compose.yml's defaults (and the overlay
+            # Secret) so the app can authenticate with the same
+            # values it uses against the compose stack.
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: postgres
+            - name: POSTGRES_DB
+              value: go-micro-example-db
+            # PGDATA inside a subdirectory of the mount lets the
+            # initialiser write to the volume cleanly (the postgres
+            # image refuses to init in a non-empty volume root).
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/deploy/overlays/local/rabbitmq.yaml
+++ b/deploy/overlays/local/rabbitmq.yaml
@@ -1,0 +1,88 @@
+# K8S-003: in-cluster RabbitMQ for the local overlay. Mirrors the
+# docker-compose layout — 4.0-management-alpine, exchanges/queues/
+# bindings loaded at boot from scripts/rabbitmq/definitions.json via
+# RabbitMQ's `load_definitions` directive — so the same DSN-015
+# topology is in place without a separate setup step.
+#
+# Service name `rabbitmq` matches the base ConfigMap's
+# GME_RABBITMQ_HOST; pod label `app.kubernetes.io/name: rabbitmq`
+# matches the base NetworkPolicy egress allow-list.
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app.kubernetes.io/name: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+      protocol: TCP
+    - name: management
+      port: 15672
+      targetPort: 15672
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  labels:
+    app.kubernetes.io/name: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:4.0-management-alpine
+          ports:
+            - name: amqp
+              containerPort: 5672
+              protocol: TCP
+            - name: management
+              containerPort: 15672
+              protocol: TCP
+          env:
+            # Default user/pass loaded from definitions.json — these
+            # env vars are redundant with the definitions but keep
+            # the credentials visible alongside the rest of the dev
+            # config.
+            - name: RABBITMQ_DEFAULT_USER
+              value: guest
+            - name: RABBITMQ_DEFAULT_PASS
+              value: guest
+          volumeMounts:
+            - name: rabbitmq-definitions
+              mountPath: /etc/rabbitmq/definitions.json
+              subPath: definitions.json
+              readOnly: true
+            - name: rabbitmq-definitions
+              mountPath: /etc/rabbitmq/rabbitmq.conf
+              subPath: rabbitmq.conf
+              readOnly: true
+          readinessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - "-q"
+                - check_running
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 30
+      volumes:
+        - name: rabbitmq-definitions
+          configMap:
+            # `rabbitmq-definitions` is built by the overlay's
+            # configMapGenerator from scripts/rabbitmq/*. Kustomize
+            # appends a content-hash suffix to the actual ConfigMap
+            # name and rewrites this reference accordingly.
+            name: rabbitmq-definitions

--- a/deploy/overlays/local/secret.yaml
+++ b/deploy/overlays/local/secret.yaml
@@ -1,0 +1,24 @@
+# K8S-003: plain dev Secret. Replaces the base ExternalSecret (which
+# the overlay $patch:deletes) so the Deployment's
+# `envFrom: { secretRef: go-micro-example-secrets }` resolves without
+# requiring External Secrets Operator + Vault. These credentials
+# match docker-compose.yml's defaults so the app's DB / AMQP /
+# JWT-signing paths exercise the same values across the two local
+# stacks.
+#
+# Dev-only. Never apply this file to a real cluster — K8S-005 wires
+# ESO + Vault and the base's ExternalSecret materialises the real
+# Secret of the same name.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: go-micro-example-secrets
+type: Opaque
+stringData:
+  GME_DB_USER: postgres
+  GME_DB_PASS: postgres
+  GME_RABBITMQ_USER: guest
+  GME_RABBITMQ_PASS: guest
+  # Stable signing key so JWTs survive a pod restart during the
+  # local-test loop (mirrors docker-compose.yml's default).
+  GME_JWT_SIGNING_KEY: demo-only-jwt-signing-key-do-not-use


### PR DESCRIPTION
Closes [K8S-003](plan/K8S-003-local-dependencies.md) — completes Tier 2 of the local-k8s ladder. Layers in-cluster Postgres / RabbitMQ + a dev Secret onto the K8S-002 image-rewrite overlay so the app pod runs against real deps without an operator install.

## Summary

- `deploy/overlays/local/postgres.yaml` — PVC + Service + Deployment (`postgres:16-alpine`), labeled `app.kubernetes.io/name: postgresql` to match the base NetworkPolicy.
- `deploy/overlays/local/rabbitmq.yaml` — Service + Deployment (`rabbitmq:4.0-management-alpine`), labeled `app.kubernetes.io/name: rabbitmq`. Loads its DSN-015 exchanges/queues/bindings from `scripts/rabbitmq/{definitions.json,rabbitmq.conf}` via a kustomize `configMapGenerator` (single source of truth with compose).
- `deploy/overlays/local/secret.yaml` — plain dev Secret with the four `GME_*` keys + JWT signing key (matches compose defaults).
- `deploy/overlays/local/namespace.yaml` — self-contained Namespace so `kubectl apply -k` doesn't require a precondition.
- `deploy/overlays/local/kustomization.yaml` — adds the new resources, declares `namespace: go-micro-example` (the base's `namespace:` directive doesn't propagate to overlay-added resources), and wires the configMapGenerator.
- Makefile: `make k8s-local-up` (kind + image-load + apply + rollout status) and `make k8s-local-down`. Both pass `--load-restrictor=LoadRestrictionsNone` so the configMapGenerator can read from `scripts/rabbitmq/`. The `k8s-validate` target carries the same flag.
- `deploy/README.md` documents the one-shot workflow and the verification log lines.

## Acceptance criteria

- [x] `make k8s-local-up` returns 0; `kubectl rollout status deploy/go-micro-example` reports the Deployment Available.
- [x] `kubectl logs deploy/go-micro-example` shows successful migrations + "ready to publish messages" log lines for `inventory.exchange`, `reservation.exchange`, `product.dlt.exchange`, plus "listening for messages queue=product.queue".
- [x] `kubectl get networkpolicy` shows the OPS-004 policy bound with the expected egress allow-list (Postgres / RabbitMQ / Redis / OTEL / DNS). Egress works in practice — the app connected to both Postgres and RabbitMQ via Service name, which the allow-list proves.
- [⚠️] `curl http://go-micro-example/ready` returns 200 — works briefly in the initial roll-out window, then flips to 503. See **TST-005 caveat** below.

## TST-005 caveat — `/ready` flips to 503 after ~10 s

The K8S-003 acceptance asks for `/ready` to return 200, but in a real kubelet readiness-probe loop the pod gets to 1/1, then both replicas drop to 0/1 inside ~15 s and stay there. Root cause is a pre-existing latent bug in the AMQP staleness check, surfaced for the first time by an actual kubelet (the docker-compose demo orchestrator probes `/ready` only at startup, masking it):

> `lastSessionAt` (in [internal/inventory/transport_queue.go](internal/inventory/transport_queue.go)) is only refreshed by `sessionOK()`, which `amqp.Publish` / `Subscribe` call on each fresh (connection, channel) pair. On a healthy long-lived session that never breaks, `sessionOK()` fires once at startup and never again, so `pingFromLastSession()` returns `amqp: no session in Xs` 10 s later.

I filed this as [TST-005](plan/TST-005-amqp-readiness-stable-session.md) — narrow fix is to refresh `lastSessionAt` on each successful publish/delivery (i.e. on session forward progress, not just on (re)connection). That's a behaviour change in `internal/platform/messaging/amqp/queue.go` + `internal/inventory/transport_queue.go` and belongs in its own ticket per the workflow's no-inline-fixes rule.

Once TST-005 lands, `make k8s-local-up` will produce a *stably* Ready pod and the rest of the K8S-003 acceptance pins down.

## Notable design calls

- **Image versions:** `postgres:16-alpine` (per ticket suggestion) and `rabbitmq:4.0-management-alpine` (matches compose). Compose's unpinned `postgres` was intentionally not mirrored — a tag pin makes the local cluster reproducible.
- **PVC backed by kind's `standard` storage class.** Dies with the cluster, which is what we want for a hermetic test loop.
- **Postgres uses `strategy: Recreate`** — RWO PVC can't attach to two pods during a rolling update.
- **`--load-restrictor=LoadRestrictionsNone`** is required because the configMapGenerator reads `scripts/rabbitmq/*` from outside the overlay directory. Trade-off: weaker locality guarantee in exchange for one source of truth between docker-compose and the k8s overlay.

## Test plan

- [x] `make k8s-local-up` exits 0 against a clean kind cluster; rollout status succeeds.
- [x] App logs show migrations + AMQP publishers + product consumer all initialized.
- [x] `kubectl describe pod` shows `Image: go-micro-example:dev` and no `ErrImagePull` events.
- [x] NetworkPolicy is bound; in-cluster Postgres / RabbitMQ connectivity proves the allow-list works.
- [x] `make verify` passes locally.
- [ ] CI: `k8s-validate` runs both base + local overlay dry-runs and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)