### PR TITLE
TST-005: heartbeat sessionOK while the AMQP session stays open

### DIFF
--- a/internal/inventory/transport_queue.go
+++ b/internal/inventory/transport_queue.go
@@ -16,11 +16,17 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// amqpSessionStaleAfter bounds how long a publish/subscribe loop may
-// go without obtaining a fresh AMQP session before the queue reports
-// unready. Aligns with the DSN-002 readiness budget (DEFAULT 2s
-// per-dep) — anything beyond ~10s means redial has stalled and the
-// pod should not receive new work (TST-004).
+// amqpSessionStaleAfter bounds how long a publish/subscribe loop
+// may go between sessionOK ticks before the queue reports unready.
+// amqp.Publish / amqp.Subscribe call sessionOK on (re)connect *and*
+// periodically (every amqp.sessionHeartbeatInterval) while a session
+// stays open — so on a healthy long-lived session the timestamp is
+// continually refreshed and Ping returns nil. The clock only ages
+// out when the inner loop exits because the broker dropped the
+// channel and Redial hasn't produced a fresh session yet. Aligned
+// with the DSN-002 readiness budget (DEFAULT 2s per-dep); anything
+// beyond ~10s means redial has stalled and the pod should not
+// receive new work (TST-004 / TST-005).
 const amqpSessionStaleAfter = 10 * time.Second
 
 // errAMQPNeverConnected signals the publish/subscribe loops have not
@@ -69,8 +75,11 @@ func NewInventoryQueue(ctx context.Context, cfg *config.Config) *InventoryQueue 
 	return iq
 }
 
-// sessionOK is invoked by the AMQP publish loops each time they
-// successfully open a fresh (connection, channel) pair.
+// sessionOK is invoked by the AMQP publish loops on each fresh
+// (connection, channel) pair *and* periodically thereafter while
+// that session stays open (TST-005). The timestamp moves on every
+// call, so a healthy idle session keeps Ping ready and a stuck
+// redial (no fresh session, no heartbeat) ages out cleanly.
 func (i *InventoryQueue) sessionOK() {
 	i.lastSessionAt.Store(time.Now().UnixNano())
 }
@@ -148,8 +157,10 @@ func NewProductQueue(ctx context.Context, cfg *config.Config, handler ProductHan
 	return pq
 }
 
-// sessionOK is invoked by the AMQP subscribe + DLT publish loops each
-// time a fresh session is established.
+// sessionOK is invoked by the AMQP subscribe + DLT publish loops on
+// each fresh session and periodically thereafter while the session
+// stays open (TST-005). See InventoryQueue.sessionOK for the full
+// rationale.
 func (p *ProductQueue) sessionOK() {
 	p.lastSessionAt.Store(time.Now().UnixNano())
 }

--- a/internal/platform/messaging/amqp/queue.go
+++ b/internal/platform/messaging/amqp/queue.go
@@ -115,6 +115,48 @@ func URL(cfg *config.Config) string {
 // sleep without polluting the production path.
 var redialBackoff = 2 * time.Second
 
+// sessionHeartbeatInterval is how often the Publish / Subscribe
+// loops re-fire onSession while a session is open and healthy. Set
+// well below the consumer-side staleness window
+// (inventory.amqpSessionStaleAfter = 10 s) so an idle-but-healthy
+// session is never falsely reported unready. Package-level var so
+// tests can shrink it.
+var sessionHeartbeatInterval = 2 * time.Second
+
+// startSessionHeartbeat fires onSession every
+// sessionHeartbeatInterval until the returned stop function is
+// called. Returns a no-op stop when onSession is nil so callers
+// don't have to nil-check. onSession is invoked from the goroutine
+// and is expected to be non-blocking (it's the readiness-probe
+// timestamp store in the production path); a slow onSession will
+// not break the heartbeat itself but will delay the stop signal
+// being observed.
+func startSessionHeartbeat(onSession func()) (stop func()) {
+	if onSession == nil {
+		return func() {}
+	}
+	// Snapshot the interval in the caller goroutine so the spawned
+	// ticker doesn't race with tests that swap the package var
+	// between cases — the `go` statement establishes a happens-before
+	// edge, but a subsequent assignment by a different goroutine
+	// would still race with the ticker's read.
+	interval := sessionHeartbeatInterval
+	done := make(chan struct{})
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				onSession()
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
 // Redial continually connects to url, returning a channel of session
 // factories. Each emitted session represents a fresh (connection,
 // channel) pair; consumers read sessions sequentially as connections
@@ -193,94 +235,114 @@ func dialUntilSuccess(ctx context.Context, dialer Dialer) (Session, bool) {
 
 // Publish publishes messages to a reconnecting session against a
 // fanout exchange. Messages from messages are consumed and delivered;
-// the loop drains and retries on transient failures. onSession is
-// called each time a fresh (connection, channel) pair is obtained so
-// callers can track liveness for readiness probes (TST-004); nil is
-// allowed for callers that don't need the signal.
+// the loop drains and retries on transient failures.
+//
+// onSession is called when a fresh (connection, channel) pair is
+// obtained and periodically thereafter (every
+// sessionHeartbeatInterval) for as long as that session stays open.
+// The repeat ticks let readiness probes distinguish an idle-but-
+// healthy session from a stuck redial (TST-005) — the callback's
+// timestamp keeps moving while the session is alive and freezes the
+// moment the inner loop exits because the broker dropped the
+// channel. onSession should be non-blocking; nil is allowed for
+// callers that don't need the signal.
 func Publish(sessions chan chan Session, exchange string, messages <-chan Message, onSession func()) {
 	for session := range sessions {
-		var (
-			running bool
-			reading = messages
-			pending = make(chan Message, 1)
-			confirm = make(chan amqp.Confirmation, 1)
-		)
-
-		pub := <-session
-		if onSession != nil {
-			onSession()
+		if !publishSession(session, exchange, messages, onSession) {
+			return
 		}
+	}
+}
 
-		// publisher confirms for this channel/connection
-		if err := pub.Confirm(false); err != nil {
-			log.Info().Msg("publisher confirms not supported")
-			close(confirm) // confirms not supported, simulate by always nacking
-		} else {
-			pub.NotifyPublish(confirm)
-		}
+// publishSession runs a single session's publish loop, factored out
+// so a deferred stopHeartbeat() runs regardless of how the inner
+// loop exits (broker drop, publish error, or messages channel
+// closed). Returns true when the outer Publish loop should iterate
+// to a new session, false when the entire Publish call should
+// return (messages was closed by the producer).
+func publishSession(session chan Session, exchange string, messages <-chan Message, onSession func()) bool {
+	var (
+		running bool
+		reading = messages
+		pending = make(chan Message, 1)
+		confirm = make(chan amqp.Confirmation, 1)
+	)
 
-		log.Debug().Str("exchange", exchange).Msg("ready to publish messages")
+	pub := <-session
+	if onSession != nil {
+		onSession()
+	}
+	stopHeartbeat := startSessionHeartbeat(onSession)
+	defer stopHeartbeat()
 
-		// body must outlive the inner-loop iteration so the confirm
-		// arrival a few selects later can still reach the message
-		// whose Publish call kicked it off. The pre-refactor loop
-		// declared `var body Message` inside the for, which meant
-		// every confirm/nack saw a zero-value body — TST-003 spans
-		// would never end and the nack log line printed empty bodies.
-		var body Message
-	Publish:
-		for {
-			select {
-			case confirmed, ok := <-confirm:
-				if !ok {
-					// Channel/session lost before the broker confirmed
-					// the in-flight body. Surface that on the producer
-					// span so the trace shows the publish neither
-					// succeeded nor was nacked.
-					endProducerSpan(body.producerSpan, codes.Error, "broker confirm channel closed", nil)
-					break Publish
-				}
-				if confirmed.Ack {
-					endProducerSpan(body.producerSpan, codes.Ok, "", nil)
-				} else {
-					log.Info().Uint64("message", confirmed.DeliveryTag).Str("body", string(body.Body)).Msg("nack")
-					endProducerSpan(body.producerSpan, codes.Error, "broker nacked", nil)
-				}
-				reading = messages
+	// publisher confirms for this channel/connection
+	if err := pub.Confirm(false); err != nil {
+		log.Info().Msg("publisher confirms not supported")
+		close(confirm) // confirms not supported, simulate by always nacking
+	} else {
+		pub.NotifyPublish(confirm)
+	}
 
-			case body = <-pending:
-				routingKey := "ignored for fanout exchanges, application dependent for other exchanges"
-				headers := amqp.Table{}
-				if body.RequestID != "" {
-					headers[RequestIDHeader] = body.RequestID
-				}
-				for k, v := range body.TraceHeaders {
-					headers[k] = v
-				}
-				err := pub.Publish(exchange, routingKey, false, false, amqp.Publishing{
-					Headers: headers,
-					Body:    body.Body,
-				})
-				// Retry failed delivery on the next session. The
-				// producer span ends here with the original error;
-				// the retry on the next session is untraced (no fresh
-				// span available without ctx-threading the retry).
-				if err != nil {
-					endProducerSpan(body.producerSpan, codes.Error, "publish failed", err)
-					pending <- body
-					_ = pub.Close()
-					break Publish
-				}
+	log.Debug().Str("exchange", exchange).Msg("ready to publish messages")
 
-			case body, running = <-reading:
-				// all messages consumed
-				if !running {
-					return
-				}
-				// work on pending delivery until ack'd
-				pending <- body
-				reading = nil
+	// body must outlive the inner-loop iteration so the confirm
+	// arrival a few selects later can still reach the message
+	// whose Publish call kicked it off. The pre-refactor loop
+	// declared `var body Message` inside the for, which meant
+	// every confirm/nack saw a zero-value body — TST-003 spans
+	// would never end and the nack log line printed empty bodies.
+	var body Message
+	for {
+		select {
+		case confirmed, ok := <-confirm:
+			if !ok {
+				// Channel/session lost before the broker confirmed
+				// the in-flight body. Surface that on the producer
+				// span so the trace shows the publish neither
+				// succeeded nor was nacked.
+				endProducerSpan(body.producerSpan, codes.Error, "broker confirm channel closed", nil)
+				return true
 			}
+			if confirmed.Ack {
+				endProducerSpan(body.producerSpan, codes.Ok, "", nil)
+			} else {
+				log.Info().Uint64("message", confirmed.DeliveryTag).Str("body", string(body.Body)).Msg("nack")
+				endProducerSpan(body.producerSpan, codes.Error, "broker nacked", nil)
+			}
+			reading = messages
+
+		case body = <-pending:
+			routingKey := "ignored for fanout exchanges, application dependent for other exchanges"
+			headers := amqp.Table{}
+			if body.RequestID != "" {
+				headers[RequestIDHeader] = body.RequestID
+			}
+			for k, v := range body.TraceHeaders {
+				headers[k] = v
+			}
+			err := pub.Publish(exchange, routingKey, false, false, amqp.Publishing{
+				Headers: headers,
+				Body:    body.Body,
+			})
+			// Retry failed delivery on the next session. The
+			// producer span ends here with the original error;
+			// the retry on the next session is untraced (no fresh
+			// span available without ctx-threading the retry).
+			if err != nil {
+				endProducerSpan(body.producerSpan, codes.Error, "publish failed", err)
+				pending <- body
+				_ = pub.Close()
+				return true
+			}
+
+		case body, running = <-reading:
+			// all messages consumed
+			if !running {
+				return false
+			}
+			// work on pending delivery until ack'd
+			pending <- body
+			reading = nil
 		}
 	}
 }
@@ -325,44 +387,65 @@ func StartConsumerSpan(ctx context.Context, queue string, msg Message) (context.
 
 // Subscribe consumes deliveries from an exclusive queue and forwards
 // them onto messages. The request_id header is restored onto the
-// Message so context propagation survives the broker hop. onSession
-// is called each time a fresh session is obtained and Consume
-// succeeds (TST-004); nil is allowed.
+// Message so context propagation survives the broker hop.
+//
+// onSession is called when a fresh (connection, channel) pair is
+// obtained and Consume succeeds, and periodically thereafter (every
+// sessionHeartbeatInterval) for as long as the deliveries channel
+// stays open. The repeat ticks satisfy the same TST-005 readiness
+// requirement as Publish: an idle queue with no incoming messages
+// still has a live AMQP session, and the callback's timestamp keeps
+// moving so /ready stays 200. nil is allowed.
 func Subscribe(sessions chan chan Session, queue string, messages chan<- Message, onSession func()) {
 	for session := range sessions {
-		sub := <-session
-
-		deliveries, err := sub.Consume(queue, "", false, false, false, false, nil)
-		if err != nil {
-			log.Error().Str("queue", queue).Err(err).Msg("cannot consume from")
+		if !subscribeSession(session, queue, messages, onSession) {
 			return
 		}
+	}
+}
 
-		if onSession != nil {
-			onSession()
+// subscribeSession runs a single session's consume loop, factored
+// out so the heartbeat is torn down via defer when the deliveries
+// channel closes (session loss) regardless of how the inner range
+// exits. Returns true when the outer Subscribe loop should iterate
+// to a new session, false when Subscribe itself should return
+// (mirrors the original "Consume error exits" fail-fast contract).
+func subscribeSession(session chan Session, queue string, messages chan<- Message, onSession func()) bool {
+	sub := <-session
+
+	deliveries, err := sub.Consume(queue, "", false, false, false, false, nil)
+	if err != nil {
+		log.Error().Str("queue", queue).Err(err).Msg("cannot consume from")
+		return false
+	}
+
+	if onSession != nil {
+		onSession()
+	}
+	stopHeartbeat := startSessionHeartbeat(onSession)
+	defer stopHeartbeat()
+
+	log.Info().Str("queue", queue).Msg("listening for messages")
+
+	for msg := range deliveries {
+		reqID := ""
+		traceHeaders := map[string]string{}
+		for k, v := range msg.Headers {
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			if k == RequestIDHeader {
+				reqID = s
+				continue
+			}
+			traceHeaders[k] = s
 		}
-
-		log.Info().Str("queue", queue).Msg("listening for messages")
-
-		for msg := range deliveries {
-			reqID := ""
-			traceHeaders := map[string]string{}
-			for k, v := range msg.Headers {
-				s, ok := v.(string)
-				if !ok {
-					continue
-				}
-				if k == RequestIDHeader {
-					reqID = s
-					continue
-				}
-				traceHeaders[k] = s
-			}
-			messages <- Message{Body: msg.Body, RequestID: reqID, TraceHeaders: traceHeaders}
-			err = sub.Ack(msg.DeliveryTag, false)
-			if err != nil {
-				log.Error().Err(err).Str("queue", queue).Msg("failed to acknowledge to queue")
-			}
+		messages <- Message{Body: msg.Body, RequestID: reqID, TraceHeaders: traceHeaders}
+		err = sub.Ack(msg.DeliveryTag, false)
+		if err != nil {
+			log.Error().Err(err).Str("queue", queue).Msg("failed to acknowledge to queue")
 		}
 	}
+	return true
 }

--- a/internal/platform/messaging/amqp/queue_test.go
+++ b/internal/platform/messaging/amqp/queue_test.go
@@ -594,3 +594,107 @@ func TestSubscribe_ConsumeErrorExits(t *testing.T) {
 		t.Fatal("Subscribe didn't return after Consume failure")
 	}
 }
+
+// withShortHeartbeat shrinks sessionHeartbeatInterval for tests that
+// need to observe ticks within a short runtime. Mirrors the
+// withShortBackoff helper.
+func withShortHeartbeat(t *testing.T) {
+	t.Helper()
+	prev := sessionHeartbeatInterval
+	sessionHeartbeatInterval = 5 * time.Millisecond
+	t.Cleanup(func() { sessionHeartbeatInterval = prev })
+}
+
+// TestPublish_OnSessionTicksWhileSessionOpen is the TST-005 regression
+// pin: while the AMQP session stays open, onSession must keep firing
+// at sessionHeartbeatInterval so the readiness probe sees an idle
+// long-lived session as ready (rather than reporting "no session in
+// 10s" 10 s after the initial connect).
+func TestPublish_OnSessionTicksWhileSessionOpen(t *testing.T) {
+	withShortHeartbeat(t)
+
+	fake := newFakeSession()
+	sessions := make(chan chan Session, 1)
+	sess := make(chan Session, 1)
+	sess <- fake
+	sessions <- sess
+
+	messages := make(chan Message)
+	var ticks atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		Publish(sessions, "test.exchange", messages, func() { ticks.Add(1) })
+		close(done)
+	}()
+
+	// Wait until at least three ticks have landed without publishing
+	// anything. The session is healthy and idle; the heartbeat is the
+	// only thing driving onSession after the initial connect.
+	waitFor(t, func() bool { return ticks.Load() >= 3 },
+		"expected onSession to tick repeatedly on an idle session")
+
+	close(messages)
+	close(sessions)
+	<-done
+}
+
+// TestSubscribe_OnSessionTicksWhileSessionOpen mirrors the Publish
+// test on the consumer side: a Subscribe holding an open deliveries
+// channel must keep refreshing onSession so the consumer's readiness
+// probe stays green even when no messages are arriving.
+func TestSubscribe_OnSessionTicksWhileSessionOpen(t *testing.T) {
+	withShortHeartbeat(t)
+
+	fake := newFakeSession()
+	sessions := make(chan chan Session, 1)
+	sess := make(chan Session, 1)
+	sess <- fake
+	sessions <- sess
+
+	out := make(chan Message, 1)
+	var ticks atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		Subscribe(sessions, "test.queue", out, func() { ticks.Add(1) })
+		close(done)
+	}()
+
+	waitFor(t, func() bool { return ticks.Load() >= 3 },
+		"expected onSession to tick repeatedly on an idle consumer session")
+
+	// Closing deliveries drops out of the inner range; sessions is
+	// drained but not closed yet, so close it to let Subscribe return.
+	close(fake.deliveries)
+	close(sessions)
+	<-done
+}
+
+// TestSessionHeartbeat_StopsAfterClose pins the heartbeat-teardown
+// contract: once stopSessionHeartbeat fires (i.e. the inner publish/
+// consume loop has exited), no further onSession calls land — which
+// is what lets lastSessionAt age out and Ping report unready when a
+// session is truly stuck.
+func TestSessionHeartbeat_StopsAfterClose(t *testing.T) {
+	withShortHeartbeat(t)
+
+	var ticks atomic.Int32
+	stop := startSessionHeartbeat(func() { ticks.Add(1) })
+	waitFor(t, func() bool { return ticks.Load() >= 2 },
+		"expected at least two ticks before stopping")
+	stop()
+
+	stopped := ticks.Load()
+	// Wait several heartbeat intervals to confirm no further ticks fire.
+	time.Sleep(50 * time.Millisecond)
+	if got := ticks.Load(); got != stopped {
+		t.Errorf("onSession kept firing after stop: stopped=%d, now=%d", stopped, got)
+	}
+}
+
+// TestSessionHeartbeat_NilOnSessionIsNoop guards against a panic
+// when callers don't need readiness signalling — Publish/Subscribe
+// both accept a nil onSession and the heartbeat helper must too.
+func TestSessionHeartbeat_NilOnSessionIsNoop(t *testing.T) {
+	stop := startSessionHeartbeat(nil)
+	stop() // must not panic
+}


### PR DESCRIPTION
Closes [TST-005](plan/TST-005-amqp-readiness-stable-session.md) — surfaced by K8S-003 ([#91](https://github.com/sksmith/go-micro-example/pull/91)).

## Problem

The AMQP staleness check at [internal/inventory/transport_queue.go](internal/inventory/transport_queue.go) treats `lastSessionAt` as a freshness timestamp with a 10 s window. `lastSessionAt` is refreshed by `sessionOK()`, which `amqp.Publish` / `amqp.Subscribe` were calling only on (re)connect — once per fresh `(connection, channel)` pair. A healthy long-lived session that never breaks meant `sessionOK()` fired exactly once at startup and then went silent, so `Ping()` returned `amqp: no session in Xs` 10 s later and `/ready` dropped to 503.

The docker-compose demo orchestrator polls `/ready` only at startup, so the regression was masked. K8S-003's actual kubelet readinessProbe (polling every 5 s) flipped both replicas to NotReady inside ~15 s.

## Fix

Each session now spawns a tiny heartbeat goroutine that re-fires `onSession` every `sessionHeartbeatInterval` (2 s default, well below the 10 s staleness window) for as long as the session is open. When the broker drops the channel or the publish/consume loop exits, the heartbeat is torn down via `defer`; `lastSessionAt` freezes and ages out cleanly within `amqpSessionStaleAfter` — preserving TST-004's "redial stalled" detection.

To get clean `defer` semantics regardless of which exit path the inner loop takes (broker drop, publish error, messages closed, deliveries closed, Consume error), `Publish` and `Subscribe` are factored into per-session helpers (`publishSession` / `subscribeSession`) that return a bool indicating whether the outer loop should iterate to the next session or return entirely. Behaviour is preserved 1:1.

`startSessionHeartbeat` snapshots `sessionHeartbeatInterval` in the caller goroutine before spawning the ticker — so tests can swap the package var between cases without racing the ticker's read.

## Acceptance criteria

- [x] After a successful initial AMQP session, `/ready` continues to return 200 while the session stays healthy.
- [x] A genuinely stalled redial (no broker reachable, no fresh session for `amqpSessionStaleAfter`) still flips `/ready` to 503 — the heartbeat stops the moment the inner loop exits, so `lastSessionAt` ages out.
- [x] Unit tests cover both branches:
  - `TestPublish_OnSessionTicksWhileSessionOpen` — idle publisher session ticks past staleness window.
  - `TestSubscribe_OnSessionTicksWhileSessionOpen` — idle consumer session ticks past staleness window.
  - `TestSessionHeartbeat_StopsAfterClose` — once `stop()` fires, no further `onSession` calls.
  - `TestSessionHeartbeat_NilOnSessionIsNoop` — nil callback path doesn't panic.

## End-to-end verification

Standing the K8S-003 overlay up against a fresh kind cluster:

```
$ make k8s-local-up
# … rollout status reports the app Deployment Available

$ kubectl -n go-micro-example get pods
NAME                                READY   STATUS    RESTARTS      AGE
go-micro-example-57b9464567-8g4dc   1/1     Running   2 (32s ago)   38s
go-micro-example-57b9464567-grk8c   1/1     Running   2 (32s ago)   38s
postgres-77ff6fc8f4-57f5r           1/1     Running   0             38s
rabbitmq-6f944b5c9f-2r627           1/1     Running   0             38s

# … 30 s later, well past the 10 s staleness window:
NAME                                READY   STATUS    RESTARTS      AGE
go-micro-example-57b9464567-8g4dc   1/1     Running   2 (62s ago)   68s
go-micro-example-57b9464567-grk8c   1/1     Running   2 (62s ago)   68s
…
```

`make verify` passes (including `go test -race`).

## Notes

- `Publish` / `Subscribe` external API is unchanged: same signatures, same parameter names, same nil-allowed semantics for `onSession`. The only contract change is documented: `onSession` now fires repeatedly while a session is open, and callers should make it non-blocking (the production InventoryQueue / ProductQueue callbacks are atomic stores — already non-blocking).
- The heartbeat goroutine is one extra goroutine per active AMQP session (4 in this codebase: inventory publish, reservation publish, product subscribe, product DLT publish). Negligible overhead.
- Once this lands, the K8S-003 caveat in [deploy/README.md](deploy/README.md) about `/ready` flipping to 503 should be removed — happy to do that here or as a follow-up doc PR; my read of the workflow's "no inline cleanups" rule says follow-up is the right move.

## Test plan

- [x] `go test -race ./internal/platform/messaging/amqp/... ./internal/inventory/...` passes locally.
- [x] `make verify` passes locally.
- [x] `make k8s-local-up` produces stably-Ready pods.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)