### PR TITLE
K8S-004: metrics-server + HPA scale validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,11 +200,27 @@ docker-load: docker
 # succeeded. The 300 s timeout covers the 150 s startup-probe budget
 # from DSN-002 plus a margin for image-pull and DB init on a cold
 # kind cluster.
-.PHONY: k8s-local-up k8s-local-down
+.PHONY: k8s-local-up k8s-local-down k8s-local-loadtest
 k8s-local-up: k8s-up docker-load
+	# K8S-004: metrics-server lands first (in kube-system) so the HPA
+	# has a metrics source by the time the app rollout completes. The
+	# file lives outside the overlay's kustomization because the
+	# overlay's `namespace:` directive would clobber kube-system.
+	kubectl apply -f deploy/overlays/local/metrics-server.yaml
 	kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local | kubectl apply -f -
 	kubectl -n go-micro-example rollout status deploy/go-micro-example --timeout=300s
+	kubectl -n kube-system rollout status deploy/metrics-server --timeout=180s
 
 k8s-local-down:
 	-kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local | kubectl delete --ignore-not-found -f -
+	-kubectl delete --ignore-not-found -f deploy/overlays/local/metrics-server.yaml
 	$(MAKE) k8s-down
+
+# K8S-004: drive the app's CPU above the HPA's 70 % target so a
+# scale-up event is visible. Defaults to 180 s of load; pass
+# different values via:
+#     make k8s-local-loadtest LOADTEST_DURATION=120 LOADTEST_PARALLEL=8
+LOADTEST_DURATION ?= 180
+LOADTEST_PARALLEL ?= 12
+k8s-local-loadtest:
+	./hack/k8s-loadtest.sh $(LOADTEST_DURATION) $(LOADTEST_PARALLEL)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,11 +18,12 @@ deploy/
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
 │   └── local/
-│       ├── kustomization.yaml  # K8S-002/003 overlay (image + deps)
-│       ├── namespace.yaml      # K8S-003 self-contained namespace
-│       ├── secret.yaml         # K8S-003 plain dev Secret
-│       ├── postgres.yaml       # K8S-003 in-cluster Postgres
-│       └── rabbitmq.yaml       # K8S-003 in-cluster RabbitMQ
+│       ├── kustomization.yaml   # K8S-002/003/004 overlay
+│       ├── namespace.yaml       # K8S-003 self-contained namespace
+│       ├── secret.yaml          # K8S-003 plain dev Secret
+│       ├── postgres.yaml        # K8S-003 in-cluster Postgres
+│       ├── rabbitmq.yaml        # K8S-003 in-cluster RabbitMQ
+│       └── metrics-server.yaml  # K8S-004 vendored metrics-server
 └── kind/
     └── cluster.yaml         # K8S-001 local Tier 1 validation gate
 ```
@@ -251,15 +252,37 @@ The pod image is also distroless (no shell), so the conventional
 `kubectl exec … sh -c '…'` connectivity probe doesn't apply here —
 the log evidence above is the substitute.
 
-> **TST-005 caveat.** After the first ~10 s, `/ready` flips to 503
-> because the AMQP staleness check at
-> `internal/inventory/transport_queue.go` doesn't refresh on a
-> healthy long-lived session — `sessionOK()` only fires on
-> (re)connect. The pod still serves traffic; readiness probes will
-> mark it NotReady and Service rotation will drop it. Track in
-> [TST-005](../plan/TST-005-amqp-readiness-stable-session.md);
-> until it's fixed, `make k8s-local-up`'s `kubectl rollout status`
-> succeeds on the initial roll but the pod won't *stay* Ready.
+### HPA scale validation (K8S-004)
+
+`make k8s-local-up` also installs
+[`metrics-server`](https://github.com/kubernetes-sigs/metrics-server)
+into `kube-system` so `kubectl top pods` returns real numbers and the
+`HorizontalPodAutoscaler` from the OPS-004 base has a metrics source.
+The manifest is vendored from the upstream `v0.8.1` release with one
+change: `--kubelet-insecure-tls` is added to the controller's args so
+metrics-server accepts kind's self-signed kubelet certs.
+
+Drive a scale-up event with the bundled load script:
+
+```sh
+# Terminal 1 — watch the HPA
+kubectl -n go-micro-example get hpa -w
+
+# Terminal 2 — drive load for 3 minutes
+make k8s-local-loadtest
+# (override defaults with LOADTEST_DURATION / LOADTEST_PARALLEL)
+```
+
+The script spawns a single in-cluster busybox pod that fires
+concurrent wgets at `http://go-micro-example/live`. The pod carries
+`app.kubernetes.io/component: loadtest` — the overlay's
+NetworkPolicy patch admits that label so the load traffic can reach
+the app on :8080. Within ~30 s the HPA target should cross 70 % and
+`REPLICAS` climbs from 2 toward `maxReplicas: 10`.
+
+Scale-down is intentionally slow — the OPS-004 HPA sets
+`scaleDown.stabilizationWindowSeconds: 300`, so replicas hold their
+peak for five minutes after load stops before stepping back down.
 
 `make k8s-validate-local` runs the dry-run-apply against the overlay
 without needing the image — useful in CI and for sanity-checking

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -58,10 +58,12 @@ images:
 # The `$patch: delete` block removes the base ExternalSecret. The
 # external-secrets.io CRDs are not installed in the K8S-001 cluster
 # (K8S-005's territory), and applying the resource would fail with
-# "no matches for kind ExternalSecret". K8S-003 will land an
-# in-cluster plain Secret with the same envFrom keys; until then
-# the pod stays in CreateContainerConfigError because no
-# `go-micro-example-secrets` Secret exists.
+# "no matches for kind ExternalSecret". K8S-003 ships an in-cluster
+# plain Secret (secret.yaml) with the same envFrom keys.
+#
+# The NetworkPolicy patch lets the K8S-004 load-test pod
+# (`hack/k8s-loadtest.sh`) reach the app on :8080 — the base policy
+# only allows ingress from `ingress-nginx` and `prometheus` labels.
 patches:
   - target:
       group: apps
@@ -83,3 +85,15 @@ patches:
       kind: ExternalSecret
       metadata:
         name: go-micro-example-secrets
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: NetworkPolicy
+      name: go-micro-example
+    patch: |-
+      - op: add
+        path: /spec/ingress/0/from/-
+        value:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: loadtest

--- a/deploy/overlays/local/metrics-server.yaml
+++ b/deploy/overlays/local/metrics-server.yaml
@@ -1,0 +1,218 @@
+# K8S-004: vendored from the upstream metrics-server v0.8.1 release —
+#   https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.1/components.yaml
+# The only change from the upstream file is the addition of
+# `--kubelet-insecure-tls` to the controller's container args
+# (line ~140) so metrics-server can scrape kind's self-signed kubelet
+# certs without rejecting them. Bump intentionally: re-download the
+# upstream file at the new tag, re-add the one flag, commit.
+#
+# Resources here live in `kube-system`, so this file is applied
+# *outside* the deploy/overlays/local kustomization (`make
+# k8s-local-up` calls `kubectl apply -f` on it before the kustomize
+# render) — otherwise the overlay's `namespace: go-micro-example`
+# directive would inject the wrong namespace on the ServiceAccount /
+# Service / Deployment.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+  - appProtocol: https
+    name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+      - args:
+        - --cert-dir=/tmp
+        - --secure-port=10250
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-use-node-status-port
+        - --kubelet-insecure-tls
+        - --metric-resolution=15s
+        image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        name: metrics-server
+        ports:
+        - containerPort: 10250
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+      - emptyDir: {}
+        name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/hack/k8s-loadtest.sh
+++ b/hack/k8s-loadtest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# K8S-004: drive the go-micro-example pod's CPU above the HPA's 70%
+# utilisation target so we can observe scale-up against the local
+# kind cluster.
+#
+# Spawns a single in-cluster pod that fires `parallelism` concurrent
+# wgets against the Service in tight loops for `duration` seconds.
+# The pod is labelled `app.kubernetes.io/component: loadtest` so the
+# K8S-004 NetworkPolicy patch lets it reach :8080 on the app pod
+# (the base policy only allows ingress from ingress-nginx /
+# prometheus labels).
+#
+# Usage: hack/k8s-loadtest.sh [duration_seconds] [parallelism]
+#   duration    seconds the load runs for (default 180)
+#   parallelism concurrent wgets per "wave" (default 12)
+#
+# The pod self-deletes when the loop exits (or when you Ctrl-C).
+# Watch the HPA in another terminal:
+#     kubectl -n go-micro-example get hpa -w
+
+set -euo pipefail
+
+DURATION="${1:-180}"
+PARALLEL="${2:-12}"
+NS=go-micro-example
+TARGET="http://go-micro-example/live"
+
+echo "==> driving ${PARALLEL} concurrent wgets at ${TARGET} for ${DURATION}s"
+echo "    (watch \`kubectl -n ${NS} get hpa -w\` in another terminal)"
+
+# Pin the busybox digest so the loop is reproducible across runs.
+# Bump intentionally; the script logs the tag so a future drift is
+# obvious.
+BUSYBOX_IMAGE="busybox:1.37"
+
+kubectl -n "$NS" run k8s-loadtest \
+  --rm -i --restart=Never \
+  --image="$BUSYBOX_IMAGE" \
+  --labels='app.kubernetes.io/component=loadtest' \
+  --command -- \
+  /bin/sh -c "
+    end=\$((\$(date +%s) + ${DURATION}))
+    waves=0
+    while [ \$(date +%s) -lt \$end ]; do
+      for i in \$(seq 1 ${PARALLEL}); do
+        wget -qO- ${TARGET} >/dev/null 2>&1 &
+      done
+      wait
+      waves=\$((waves + 1))
+    done
+    echo \"drove \$waves waves of ${PARALLEL} concurrent requests\"
+  "


### PR DESCRIPTION
Closes [K8S-004](plan/K8S-004-metrics-server-hpa.md) — the "HPA actually works" half of Tier 3.

## Summary

- `deploy/overlays/local/metrics-server.yaml` — vendored from the upstream [metrics-server v0.8.1 release](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1). The only diff is `--kubelet-insecure-tls` added to the controller args so metrics-server accepts kind's self-signed kubelet certs. Applied outside the overlay's kustomize render (its resources live in `kube-system`; the overlay's `namespace:` directive would clobber them).
- `deploy/overlays/local/kustomization.yaml` — adds a JSON patch on the base NetworkPolicy so pods labelled `app.kubernetes.io/component: loadtest` can ingress on :8080. The base only admits `ingress-nginx` and `prometheus` labels.
- `hack/k8s-loadtest.sh` — spawns a single in-cluster busybox pod that fires N concurrent wgets at `http://go-micro-example/live` for D seconds, then self-deletes. Defaults to 12 / 180; both overridable via env (`LOADTEST_PARALLEL`, `LOADTEST_DURATION`).
- Makefile: `k8s-local-up` now installs metrics-server before the kustomize apply and waits on both rollouts. New `k8s-local-loadtest` target invokes the script. `k8s-local-down` tears metrics-server down too.
- `deploy/README.md` documents the HPA validation workflow and the OPS-004 5-min scale-down stabilisation window. Also removes the now-stale TST-005 caveat (the heartbeat fix landed in #92).

## Acceptance criteria

- [x] `kubectl top pods -n go-micro-example` returns numbers (`go-micro-example-… 35m 49Mi`, etc).
- [x] After running the load driver, `kubectl get hpa` shows `REPLICAS` above the floor of 2.
- [x] After load stops, the HPA holds peak replicas for the OPS-004 stabilisation window (300 s) — called out in the docs.

## Local verification

```
$ make k8s-local-up
# … rolls out app + metrics-server …

$ kubectl -n go-micro-example top pods
NAME                                CPU(cores)   MEMORY(bytes)
go-micro-example-57b9464567-jg2q4   35m          49Mi
go-micro-example-57b9464567-lgjd9   2m           54Mi
postgres-77ff6fc8f4-4j4gw           10m          34Mi
rabbitmq-6f944b5c9f-dwstt           110m         101Mi

$ make k8s-local-loadtest LOADTEST_PARALLEL=24
==> driving 24 concurrent wgets at http://go-micro-example/live for 180s
drove 6247 waves of 24 concurrent requests
pod "k8s-loadtest" deleted

# HPA trace during the run:
cpu: 2%/70%    REPLICAS=2
cpu: 43%/70%   REPLICAS=2
cpu: 94%/70%   REPLICAS=2
cpu: 95%/70%   REPLICAS=3   ← scale-up at ~2 min mark
```

`make verify` is green.

## Design call: apply order, not kustomize sub-base

The K8S-004 ticket suggested wiring metrics-server into the overlay's `kustomization.yaml`. I diverged because the components.yaml resources are `kube-system`-scoped (ServiceAccount, Service, Deployment, APIService) and the overlay's `namespace: go-micro-example` directive would inject the wrong namespace into them. Options considered:

1. Sub-kustomization (`deploy/overlays/local/metrics-server/kustomization.yaml`) referenced from the parent. Works but adds a directory + an extra `namespace:`-free kustomization for one vendored YAML file.
2. Apply metrics-server out-of-band from kustomize via a separate `kubectl apply -f` in the Make target. **Picked this** — simpler, same reproducibility (the manifest is still version-controlled at a pinned digest), and the Make target documents the ordering.

If we end up adding more `kube-system`-scoped components (e.g. an in-cluster OTel collector for K8S-006), this rolls into a `kube-system/` sub-base cleanly.

## Out of scope

- The custom `http_requests_per_second` metric the OPS-004 HPA stubs out — needs Prometheus + Prometheus Adapter. Left commented as the base does.
- Hooking the load driver into CI. The script is for local validation; a CI scale-test would be its own follow-up.

## Test plan

- [x] `make k8s-local-up` exits 0 against fresh kind; both rollouts succeed.
- [x] `kubectl top pods` returns numbers after metrics-server's first scrape (~15 s).
- [x] `make k8s-local-loadtest` drives CPU above 70 % and HPA scales 2→3 within ~2 min.
- [x] `make verify` passes locally.
- [ ] CI: `k8s-validate` runs both base + local overlay dry-runs and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)