### PR TITLE
K8S-009: pgAdmin overlay for in-cluster Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,17 @@ k8s-local-ui-rabbitmq:
 	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:15672) &
 	kubectl -n go-micro-example port-forward svc/rabbitmq 15672:15672
 
+# K8S-009: open pgAdmin for the in-cluster postgres Service. The pod
+# ships a preconfigured server entry pointing at `postgres:5432`, so
+# the `go-micro-example` tree unfolds without manual setup; the
+# operator types the password on first connect.
+.PHONY: k8s-local-ui-pgadmin
+k8s-local-ui-pgadmin:
+	@echo "pgAdmin: http://localhost:9090  (admin@example.com / admin)"
+	@echo "Postgres password (when prompted for the 'go-micro-example' server): postgres"
+	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:9090) &
+	kubectl -n go-micro-example port-forward svc/pgadmin 9090:80
+
 # K8S-005: ESO-flavoured local stack — installs External Secrets
 # Operator, brings up an in-cluster dev Vault, seeds the secret
 # paths the base ExternalSecret references, and rolls out the app

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,12 +17,13 @@ deploy/
 │   ├── networkpolicy.yaml   # default-deny + per-dependency allows
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
-│   ├── local/                   # K8S-002/003/004/006 (plain Secret)
+│   ├── local/                   # K8S-002/003/004/006/009 (plain Secret)
 │   │   ├── kustomization.yaml
 │   │   ├── namespace.yaml
 │   │   ├── secret.yaml          # plain dev Secret
 │   │   ├── postgres.yaml
 │   │   ├── rabbitmq.yaml
+│   │   ├── pgadmin.yaml         # K8S-009 pgAdmin UI for Postgres
 │   │   ├── metrics-server.yaml
 │   │   ├── kube-network-policies.yaml  # NetworkPolicy enforcer
 │   │   └── otel-collector.yaml  # K8S-006 OTel collector
@@ -295,6 +296,36 @@ image for browsing convenience; the OPS-004 base does not pull this
 tag. Real deployments either disable the plugin (`rabbitmq-plugins
 disable rabbitmq_management`) or restrict it to a management
 network — exposing :15672 publicly is a security incident.
+
+#### pgAdmin for Postgres (K8S-009)
+
+`docker-compose.yml` ships a pgAdmin alongside Postgres so developers
+can browse rows, inspect migrations, and run ad-hoc SQL without a
+desktop client. The local overlay mirrors that — `pgadmin.yaml`
+defines a Deployment + Service + ConfigMap (`servers.json`) that
+preconfigures a server entry pointing at the in-cluster `postgres`
+Service.
+
+```sh
+make k8s-local-ui-pgadmin
+# pgAdmin: http://localhost:9090  (admin@example.com / admin)
+# Postgres password (when prompted for the 'go-micro-example' server): postgres
+```
+
+The target port-forwards `svc/pgadmin 9090:80`, prints the admin
+credentials and the Postgres password, and (on macOS) opens a
+browser tab. Sign in with `admin@example.com` / `admin`. The tree
+on the left should already show **Local → go-micro-example** —
+expand it, supply `postgres` as the password on first connect, and
+browse **Databases → go-micro-example-db → Schemas → public →
+Tables** to confirm the migrations applied (`products`,
+`product_inventory`, `production_events`, `users`,
+`idempotency_keys`, plus a few migration-tracking tables).
+
+The pgAdmin pod is intentionally stateless: `/var/lib/pgadmin`
+mounts an `emptyDir`, so saved queries vanish with the cluster.
+`make k8s-local-down` removes the pgAdmin Deployment, Service, and
+ConfigMap along with the rest of the overlay.
 
 #### NetworkPolicy enforcement on kind
 

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -33,6 +33,10 @@ resources:
   # prints them via the debug exporter — see otel-collector.yaml +
   # the OTEL_EXPORTER_OTLP_ENDPOINT patch in this file.
   - otel-collector.yaml
+  # K8S-009: pgAdmin pod preconfigured with a server entry pointing
+  # at the in-cluster postgres Service. Browsable via
+  # `make k8s-local-ui-pgadmin`.
+  - pgadmin.yaml
 
 # RabbitMQ loads its exchanges/queues/bindings from
 # scripts/rabbitmq/definitions.json on boot (DSN-015). Mounting the

--- a/deploy/overlays/local/pgadmin.yaml
+++ b/deploy/overlays/local/pgadmin.yaml
@@ -1,0 +1,109 @@
+# K8S-009: in-cluster pgAdmin for the local overlay. Mirrors the
+# docker-compose `pgadmin` service so developers can browse rows,
+# inspect migrations, and run ad-hoc SQL without leaving the kind
+# cluster. The preconfigured server connection (servers.json) lands
+# the operator on the `go-micro-example-db` database the migrations
+# write to without any manual setup.
+#
+# Dev-only. No persistent storage (the dev workflow is "throwaway
+# cluster"); the admin credentials are hard-coded to admin@example.com
+# / admin to match docker-compose.yml's defaults.
+#
+# The pgAdmin pod is not subject to the base NetworkPolicy (different
+# label), so its egress to `postgres:5432` and ingress from the
+# operator's port-forward are unconstrained.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgadmin-servers
+data:
+  # Preconfigured server registration mounted at
+  # /pgadmin4/servers.json. pgAdmin loads it on first container start
+  # so the `go-micro-example` server entry shows up under the Local
+  # group without manual "Register Server" clicks. The operator still
+  # has to type the password on first connect — saving it via
+  # PGPASSFILE is a larger setup for marginal benefit in dev.
+  servers.json: |
+    {
+      "Servers": {
+        "1": {
+          "Name": "go-micro-example",
+          "Group": "Local",
+          "Host": "postgres",
+          "Port": 5432,
+          "MaintenanceDB": "go-micro-example-db",
+          "Username": "postgres",
+          "SSLMode": "disable"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+spec:
+  selector:
+    app.kubernetes.io/name: pgadmin
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+  labels:
+    app.kubernetes.io/name: pgadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pgadmin
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pgadmin
+    spec:
+      containers:
+        - name: pgadmin
+          image: dpage/pgadmin4:9
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: PGADMIN_DEFAULT_EMAIL
+              value: admin@example.com
+            - name: PGADMIN_DEFAULT_PASSWORD
+              value: admin
+            # Skip the "Server mode" desktop-vs-server upgrade dialog
+            # on every login by pinning the mode. False ⇒ desktop
+            # mode, which is the docker-compose default and lets a
+            # single user sign in without LDAP/OAUTH glue.
+            - name: PGADMIN_CONFIG_SERVER_MODE
+              value: "False"
+            - name: PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED
+              value: "False"
+          volumeMounts:
+            - name: servers
+              mountPath: /pgadmin4/servers.json
+              subPath: servers.json
+              readOnly: true
+            # /var/lib/pgadmin is where the container writes its
+            # SQLite config DB and session data. The pgAdmin image
+            # refuses to start if the directory is not writable.
+            # emptyDir keeps the dev workflow stateless — saved
+            # queries vanish with the cluster.
+            - name: data
+              mountPath: /var/lib/pgadmin
+      volumes:
+        - name: servers
+          configMap:
+            name: pgadmin-servers
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

Mirrors the docker-compose `pgadmin` service into
`deploy/overlays/local/` so the kind cluster has a clickable
row/schema browser for the in-cluster Postgres.

- `deploy/overlays/local/pgadmin.yaml` — Deployment + Service +
  ConfigMap. The ConfigMap supplies a preconfigured `servers.json`
  mounted at `/pgadmin4/servers.json`, so the *go-micro-example*
  server entry shows up on first login without manual setup.
  `/var/lib/pgadmin` is an `emptyDir` — saved queries vanish with
  the throwaway cluster.
- `deploy/overlays/local/kustomization.yaml` — adds `pgadmin.yaml`
  to the `resources:` list.
- `make k8s-local-ui-pgadmin` — port-forwards `svc/pgadmin
  9090:80`, prints admin credentials and the postgres password,
  and (on macOS) opens a browser tab.
- `deploy/README.md` — grows a **pgAdmin for Postgres** subsection
  under the K8S-003 walk-through and adds the new file to the
  directory tree at the top.

The pgAdmin pod isn't matched by the base NetworkPolicy
podSelector, so its egress to `postgres:5432` and ingress from the
operator's port-forward are unconstrained — no NetworkPolicy patch
needed.

Ticket: `plan/K8S-009-postgres-ui.md`.

## Acceptance criteria

- [x] After `make k8s-local-up`, `make k8s-local-ui-pgadmin` lands
  the operator on the pgAdmin login page.
- [x] After logging in, the `go-micro-example` server in the tree
  unfolds without manual config; schema browser shows the migrated
  tables.
- [x] `make k8s-local-down` removes pgAdmin cleanly.

## Test plan

- [ ] `kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local` renders without error.
- [ ] `make k8s-local-up` brings up the overlay including pgAdmin.
- [ ] `make k8s-local-ui-pgadmin` opens the UI; login works with
  `admin@example.com` / `admin`.
- [ ] Expanding **Local → go-micro-example** prompts for password,
  accepts `postgres`, and shows the migrated tables.
- [ ] `make k8s-local-down` removes pgAdmin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)