### PR TITLE
K8S-012: Metrics UI (Prometheus + Grafana)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,15 @@ LOADTEST_PARALLEL ?= 12
 k8s-local-loadtest:
 	./hack/k8s-loadtest.sh $(LOADTEST_DURATION) $(LOADTEST_PARALLEL)
 
+# K8S-011 / K8S-012: open the in-cluster Grafana. Shared by both
+# tickets — K8S-011 provisions a Loki datasource, K8S-012 appends a
+# Prometheus datasource, but the entry point is one URL.
+.PHONY: k8s-local-ui-grafana
+k8s-local-ui-grafana:
+	@echo "Grafana: http://localhost:3000  (admin / admin)"
+	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:3000) &
+	kubectl -n go-micro-example port-forward svc/grafana 3000:3000
+
 # K8S-005: ESO-flavoured local stack — installs External Secrets
 # Operator, brings up an in-cluster dev Vault, seeds the secret
 # paths the base ExternalSecret references, and rolls out the app

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,15 @@ k8s-local-ui-grafana:
 	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:3000) &
 	kubectl -n go-micro-example port-forward svc/grafana 3000:3000
 
+# K8S-012: open the Prometheus expression browser. Useful for
+# /targets (annotation-discovered scrape targets) and ad-hoc PromQL
+# without the Grafana dashboard wrapper.
+.PHONY: k8s-local-ui-prometheus
+k8s-local-ui-prometheus:
+	@echo "Prometheus: http://localhost:9090  (/targets, /graph)"
+	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:9090) &
+	kubectl -n go-micro-example port-forward svc/prometheus 9090:9090
+
 # K8S-005: ESO-flavoured local stack — installs External Secrets
 # Operator, brings up an in-cluster dev Vault, seeds the secret
 # paths the base ExternalSecret references, and rolls out the app

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@ deploy/
 │   ├── networkpolicy.yaml   # default-deny + per-dependency allows
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
-│   ├── local/                   # K8S-002/003/004/006 (plain Secret)
+│   ├── local/                   # K8S-002/003/004/006/011 (plain Secret)
 │   │   ├── kustomization.yaml
 │   │   ├── namespace.yaml
 │   │   ├── secret.yaml          # plain dev Secret
@@ -25,7 +25,10 @@ deploy/
 │   │   ├── rabbitmq.yaml
 │   │   ├── metrics-server.yaml
 │   │   ├── kube-network-policies.yaml  # NetworkPolicy enforcer
-│   │   └── otel-collector.yaml  # K8S-006 OTel collector
+│   │   ├── otel-collector.yaml  # K8S-006 OTel collector
+│   │   ├── loki.yaml            # K8S-011 Loki single-binary
+│   │   ├── promtail.yaml        # K8S-011 Promtail log shipper
+│   │   └── grafana.yaml         # K8S-011/012 Grafana UI
 │   └── local-eso/               # K8S-005 (ESO + dev Vault)
 │       ├── kustomization.yaml
 │       ├── external-secrets-operator.yaml
@@ -398,6 +401,56 @@ that happen during the same window. The K8S-004 load test driving
 emitted in parallel. For trace verification, run the smoke test
 above when no load driver is active, or lower
 `OTEL_TRACES_SAMPLER_ARG` in the overlay.
+
+### Logs UI: Loki + Grafana (K8S-011)
+
+`kubectl logs deploy/go-micro-example` is fine for one-pod
+debugging but doesn't scale — there's no way to follow a
+`request_id` through the inventory queue's consumer or correlate
+across pods at the same timestamp. The local overlay runs the
+canonical Grafana log stack so the DSN-005 structured-log fields
+actually pay off in a UI:
+
+- **Loki** (single-binary, in-memory filesystem storage) on
+  `svc/loki:3100`.
+- **Promtail** (DaemonSet) tails `/var/log/pods/**` on the node and
+  ships every container's logs to Loki. RBAC is read-only against
+  pods/services/endpoints.
+- **Grafana** (`svc/grafana:3000`, admin / admin) with a
+  provisioned Loki datasource and a starter dashboard.
+
+```sh
+make k8s-local-ui-grafana
+# Grafana: http://localhost:3000  (admin / admin)
+```
+
+The target port-forwards `svc/grafana 3000:3000` and (on macOS)
+opens a browser tab.
+
+What to verify on first visit:
+
+- **Dashboards → go-micro-example logs** — renders the
+  `{namespace="go-micro-example"}` panel; recent app log lines
+  appear within seconds of pod startup.
+- **Explore → Loki** — type
+  `{namespace="go-micro-example"} |= "listening"` and confirm the
+  startup-banner line appears. Add `| json` to extract
+  `request_id` / `trace_id` from a structured JSON line.
+- **Datasources → Loki → Test** — reports "Data source connected
+  and labels found".
+
+Stopping Loki (`kubectl -n go-micro-example scale deploy/loki
+--replicas=0`) and watching Grafana's Explore page raise a clean
+"datasource unreachable" banner confirms the integration is live
+and not pre-rendered.
+
+**Dev-only posture.** Single-replica Loki, in-memory ring, and
+filesystem storage on an `emptyDir` mean logs vanish on pod
+restart. Promtail mounts the host's `/var/log/pods` directly, which
+real clusters typically restrict via PodSecurity. A production
+deployment would use the Grafana Loki helm chart with object
+storage, run several replicas, and replace Promtail with Grafana
+Alloy or vector.dev.
 
 ### Real ExternalSecret flow against in-cluster Vault (K8S-005)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@ deploy/
 │   ├── networkpolicy.yaml   # default-deny + per-dependency allows
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
-│   ├── local/                   # K8S-002/003/004/006/011 (plain Secret)
+│   ├── local/                   # K8S-002/003/004/006/011/012 (plain Secret)
 │   │   ├── kustomization.yaml
 │   │   ├── namespace.yaml
 │   │   ├── secret.yaml          # plain dev Secret
@@ -28,7 +28,8 @@ deploy/
 │   │   ├── otel-collector.yaml  # K8S-006 OTel collector
 │   │   ├── loki.yaml            # K8S-011 Loki single-binary
 │   │   ├── promtail.yaml        # K8S-011 Promtail log shipper
-│   │   └── grafana.yaml         # K8S-011/012 Grafana UI
+│   │   ├── grafana.yaml         # K8S-011/012 Grafana UI
+│   │   └── prometheus.yaml      # K8S-012 annotation-scrape Prometheus
 │   └── local-eso/               # K8S-005 (ESO + dev Vault)
 │       ├── kustomization.yaml
 │       ├── external-secrets-operator.yaml
@@ -451,6 +452,55 @@ real clusters typically restrict via PodSecurity. A production
 deployment would use the Grafana Loki helm chart with object
 storage, run several replicas, and replace Promtail with Grafana
 Alloy or vector.dev.
+
+### Metrics UI: Prometheus + Grafana (K8S-012)
+
+The OPS-004 base sets `prometheus.io/scrape: "true"`,
+`prometheus.io/port: "8080"`, and `prometheus.io/path: "/metrics"`
+on the app pod template, but no scraper was running in the cluster
+— so the chi middleware's `url_hit_count` / `url_latency` series,
+the SEC-002b Basic-Auth counter, and the Go runtime metrics were
+all unindexed. The local overlay now lands a single-replica
+Prometheus that picks the app up via those annotations, plus a
+Grafana datasource and starter dashboard that visualise the
+result.
+
+```sh
+make k8s-local-ui-prometheus
+# Prometheus: http://localhost:9090  (/targets, /graph)
+
+make k8s-local-ui-grafana
+# Grafana: http://localhost:3000  (admin / admin)
+```
+
+First-visit checks:
+
+- **Prometheus → Status → Targets** — the `kubernetes-pods` job
+  shows the app pod as `UP`, scraped at
+  `<pod-ip>:8080/metrics`. No ServiceMonitor / PodMonitor required.
+- **Prometheus → Graph** — type
+  `sum(rate(url_hit_count[1m])) by (url)` and execute. After a
+  short burst of traffic (`make k8s-local-loadtest`) the panel
+  fills in.
+- **Grafana → Dashboards → go-micro-example metrics** — renders
+  the RPS, p99 latency, goroutines, heap, GC pause, and the
+  SEC-002b Basic-Auth counter (which should remain at 0
+  post-SEC-002c).
+
+The Prometheus pod carries
+`app.kubernetes.io/name: prometheus`, which the base
+NetworkPolicy's ingress allow-list already admits on TCP 8080 —
+so the scrape path works without an overlay patch.
+
+**Dev-only posture.** Single replica, in-memory TSDB on an
+emptyDir, 2-hour retention. No Alertmanager, no Prometheus
+Adapter, no Thanos. Production would either use
+`kube-prometheus-stack` (Operator + Alertmanager + Grafana +
+recording rules) or hand a long-term-storage backend like Mimir.
+
+The HPA custom-metric path (`http_requests_per_second` via the
+Prometheus Adapter against `external.metrics.k8s.io`) is a
+separate follow-up — K8S-004 stubs it out in `deploy/base/hpa.yaml`.
 
 ### Real ExternalSecret flow against in-cluster Vault (K8S-005)
 

--- a/deploy/overlays/local/grafana.yaml
+++ b/deploy/overlays/local/grafana.yaml
@@ -21,6 +21,10 @@ data:
     apiVersion: 1
     datasources:
       - name: Loki
+        # Stable UID so committed dashboards can reference this
+        # datasource by uid="Loki" without depending on Grafana's
+        # generated hash.
+        uid: Loki
         type: loki
         access: proxy
         url: http://loki:3100
@@ -30,6 +34,17 @@ data:
           # Explore doesn't pull a multi-hour range and hang the
           # single-binary Loki.
           maxLines: 1000
+      # K8S-012: Prometheus datasource. Lands here so Grafana can be
+      # the single entry point for logs (Loki) and metrics
+      # (Prometheus). The Prometheus pod scrapes pods annotated
+      # `prometheus.io/scrape: "true"` (the OPS-004 base sets this on
+      # the app), so its /targets page is the canonical place to
+      # confirm the chi metrics endpoint is reachable.
+      - name: Prometheus
+        uid: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -56,9 +71,9 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboards
 data:
-  # Starter dashboard: a single LogQL panel for the app namespace
-  # plus a logs-by-pod panel. Operators can pin further dashboards
-  # via Explore once they're past the smoke check.
+  # Starter logs dashboard (K8S-011): a single LogQL panel filtered
+  # to the app namespace. Operators can pin further dashboards via
+  # Explore once they're past the smoke check.
   go-micro-example-logs.json: |
     {
       "annotations": {"list": []},
@@ -85,6 +100,98 @@ data:
       "schemaVersion": 39,
       "title": "go-micro-example logs",
       "uid": "gme-logs",
+      "version": 1
+    }
+  # Starter metrics dashboard (K8S-012): chi middleware RPS + latency
+  # and Go runtime panels. The `url_hit_count` / `url_latency` series
+  # come from internal/platform/httpx/middleware.go; the `go_*`
+  # series are the runtime metrics promhttp registers automatically.
+  go-micro-example-metrics.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "HTTP RPS by route",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "sum by (url) (rate(url_hit_count{namespace=\"go-micro-example\"}[1m]))",
+              "legendFormat": "{{url}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "HTTP latency p99 by route (seconds)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "url_latency{namespace=\"go-micro-example\", quantile=\"0.99\"}",
+              "legendFormat": "{{url}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "Goroutines",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_goroutines{namespace=\"go-micro-example\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8}
+        },
+        {
+          "type": "timeseries",
+          "title": "Heap in use (bytes)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_memstats_heap_inuse_bytes{namespace=\"go-micro-example\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8}
+        },
+        {
+          "type": "timeseries",
+          "title": "GC pause (seconds, p99)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_gc_duration_seconds{namespace=\"go-micro-example\", quantile=\"1\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8}
+        },
+        {
+          "type": "stat",
+          "title": "Basic Auth attempts (SEC-002b, should be 0)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "sum(auth_basic_auth_attempts_total{namespace=\"go-micro-example\"})",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 4, "w": 24, "x": 0, "y": 16}
+        }
+      ],
+      "schemaVersion": 39,
+      "title": "go-micro-example metrics",
+      "uid": "gme-metrics",
       "version": 1
     }
 ---

--- a/deploy/overlays/local/grafana.yaml
+++ b/deploy/overlays/local/grafana.yaml
@@ -1,0 +1,190 @@
+# K8S-011: in-cluster Grafana for browsing logs (Loki datasource).
+# K8S-012 lands a Prometheus datasource alongside this one by
+# appending an additional entry to the provisioning ConfigMap;
+# whichever ticket lands first installs Grafana, the second only
+# touches the datasource list.
+#
+# Anonymous access is disabled; admin/admin is the dev login. The
+# pod is stateless — saved dashboards (other than the
+# provisioning-ConfigMap defaults below) vanish with the cluster.
+#
+# Not subject to the base NetworkPolicy podSelector; egress to
+# loki:3100 and (in K8S-012) prometheus:9090 is unconstrained.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+data:
+  # /etc/grafana/provisioning/datasources/datasources.yaml is loaded
+  # at boot — see GF_PATHS_PROVISIONING in the Deployment env block.
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki:3100
+        isDefault: true
+        jsonData:
+          # Bound the streaming window so a bad LogQL query in
+          # Explore doesn't pull a multi-hour range and hang the
+          # single-binary Loki.
+          maxLines: 1000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-provider
+data:
+  # Tell Grafana where to look for committed dashboards. The
+  # provider points at /etc/grafana/dashboards, which the
+  # Deployment mounts from the grafana-dashboards ConfigMap.
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        type: file
+        disableDeletion: false
+        editable: true
+        updateIntervalSeconds: 30
+        options:
+          path: /etc/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+data:
+  # Starter dashboard: a single LogQL panel for the app namespace
+  # plus a logs-by-pod panel. Operators can pin further dashboards
+  # via Explore once they're past the smoke check.
+  go-micro-example-logs.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "type": "logs",
+          "title": "go-micro-example logs",
+          "datasource": {"type": "loki", "uid": "Loki"},
+          "targets": [
+            {
+              "expr": "{namespace=\"go-micro-example\"}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 16, "w": 24, "x": 0, "y": 0},
+          "options": {
+            "showTime": true,
+            "wrapLogMessage": true,
+            "enableLogDetails": true
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "title": "go-micro-example logs",
+      "uid": "gme-logs",
+      "version": 1
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+    spec:
+      # Grafana 11 runs as UID 472. The image itself sets this in
+      # USER but kind's default PodSecurity restricted profile won't
+      # complain about an explicit non-root setting.
+      securityContext:
+        fsGroup: 472
+        runAsUser: 472
+        runAsGroup: 472
+        runAsNonRoot: true
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.6.4
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+            # Suppress the first-login "change your password" wall —
+            # the dev creds are documented in the README; forcing a
+            # change here just adds a click.
+            - name: GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION
+              value: "false"
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            # Don't phone home or run the news/version checks from a
+            # dev cluster.
+            - name: GF_ANALYTICS_REPORTING_ENABLED
+              value: "false"
+            - name: GF_ANALYTICS_CHECK_FOR_UPDATES
+              value: "false"
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboards-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards
+              mountPath: /etc/grafana/dashboards
+              readOnly: true
+            - name: storage
+              mountPath: /var/lib/grafana
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboards-provider
+          configMap:
+            name: grafana-dashboards-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+        - name: storage
+          emptyDir: {}

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -33,6 +33,14 @@ resources:
   # prints them via the debug exporter — see otel-collector.yaml +
   # the OTEL_EXPORTER_OTLP_ENDPOINT patch in this file.
   - otel-collector.yaml
+  # K8S-011: Loki + Promtail + Grafana. Promtail (DaemonSet) tails
+  # the kubelet's pod logs and ships to Loki; Grafana provides the
+  # Logs UI via a provisioned Loki datasource. Grafana's datasource
+  # ConfigMap is the shared seam K8S-012 (metrics) appends a
+  # Prometheus entry to.
+  - loki.yaml
+  - promtail.yaml
+  - grafana.yaml
 
 # RabbitMQ loads its exchanges/queues/bindings from
 # scripts/rabbitmq/definitions.json on boot (DSN-015). Mounting the

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -41,6 +41,10 @@ resources:
   - loki.yaml
   - promtail.yaml
   - grafana.yaml
+  # K8S-012: Prometheus + the SEC-002b / chi-middleware / Go-runtime
+  # dashboards. Scrapes the OPS-004 `prometheus.io/scrape: "true"`
+  # annotation on the app pod, so no per-target config is required.
+  - prometheus.yaml
 
 # RabbitMQ loads its exchanges/queues/bindings from
 # scripts/rabbitmq/definitions.json on boot (DSN-015). Mounting the

--- a/deploy/overlays/local/loki.yaml
+++ b/deploy/overlays/local/loki.yaml
@@ -1,0 +1,134 @@
+# K8S-011: in-cluster Loki for the local overlay. Single-binary mode
+# (target=all) keeps the whole log-ingest / query stack in one pod
+# with filesystem storage backed by an emptyDir — fine for the
+# throwaway dev cluster, decisively not for production (no
+# replication, ephemeral storage, single point of contention).
+#
+# Promtail (see promtail.yaml) ships node-local container logs here;
+# Grafana (see grafana.yaml) queries this Service for the Logs UI.
+#
+# The Loki pod isn't matched by the base NetworkPolicy podSelector
+# (different label), so the Promtail→Loki and Grafana→Loki egress
+# paths are unconstrained.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+data:
+  config.yaml: |
+    # Single-binary Loki: every component (distributor, ingester,
+    # querier, store-gateway, ruler) runs in this process. Sized for
+    # local-dev volume; a real deployment would split components and
+    # use object storage with a backing index DB.
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9095
+      # Loki's healthz handler is only available after the ring is up;
+      # the readiness probe in the Deployment retries until that's true.
+      log_level: info
+
+    common:
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      # DSN-005 logs ship JSON with `request_id` / `trace_id` fields;
+      # structured-metadata extraction (LogQL `| json`) requires the
+      # v13 schema and this flag.
+      allow_structured_metadata: true
+      # Reject samples older than 24h — local dev never needs longer.
+      reject_old_samples: true
+      reject_old_samples_max_age: 24h
+
+    analytics:
+      # Don't phone home from a dev cluster.
+      reporting_enabled: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+spec:
+  selector:
+    app.kubernetes.io/name: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  labels:
+    app.kubernetes.io/name: loki
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+    spec:
+      containers:
+        - name: loki
+          # 3.5.x is the current Loki series with the v13 schema and
+          # structured-metadata support the JSON-parsing recipes above
+          # rely on.
+          image: grafana/loki:3.5.1
+          args:
+            - -config.file=/etc/loki/config.yaml
+            - -target=all
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            failureThreshold: 30
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+              readOnly: true
+            - name: data
+              mountPath: /loki
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          emptyDir: {}

--- a/deploy/overlays/local/prometheus.yaml
+++ b/deploy/overlays/local/prometheus.yaml
@@ -1,0 +1,180 @@
+# K8S-012: in-cluster Prometheus for the local overlay. Single
+# replica, in-memory TSDB on an emptyDir, no remote_write — sized
+# for the dev loop. Annotation-driven scrape so the OPS-004 base
+# `prometheus.io/scrape` / `prometheus.io/port` / `prometheus.io/path`
+# annotations are sufficient; no ServiceMonitor / PodMonitor CRDs
+# required.
+#
+# The pod carries `app.kubernetes.io/name: prometheus` which matches
+# the base NetworkPolicy's ingress allow-list for :8080, so the
+# scrape path to the app pod is unconstrained by the policy.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: go-micro-example
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      # Annotation-driven pod scrape: any pod with
+      # `prometheus.io/scrape: "true"` is included; `prometheus.io/port`
+      # selects the port and `prometheus.io/path` selects the metrics
+      # path. The OPS-004 base sets all three on the app's pod
+      # template, so the app shows up here with zero per-target
+      # config.
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: replace
+            target_label: container
+
+      # Scrape Prometheus itself so the Targets page has at least one
+      # always-up entry while the dev cluster boots.
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        # The base NetworkPolicy admits ingress to the app's :8080
+        # from any pod carrying this label, so the scrape path works
+        # out of the box.
+        app.kubernetes.io/name: prometheus
+    spec:
+      serviceAccountName: prometheus
+      # Prometheus 3.x runs as UID 65534 (nobody).
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        fsGroup: 65534
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.6.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            # Short retention — local dev doesn't need history beyond
+            # the current session.
+            - --storage.tsdb.retention.time=2h
+            - --web.enable-lifecycle
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}

--- a/deploy/overlays/local/promtail.yaml
+++ b/deploy/overlays/local/promtail.yaml
@@ -1,0 +1,186 @@
+# K8S-011: Promtail DaemonSet that tails the kubelet's container log
+# directory and ships lines to the in-cluster Loki Service. Runs on
+# every node (kind clusters default to one) and discovers pods via
+# the kube API.
+#
+# RBAC: the ServiceAccount needs `get/list/watch` on pods (for
+# kubernetes_sd_configs role=pod). No `create/update/delete` —
+# Promtail is read-only.
+#
+# Filesystem access: /var/log/pods (where the kubelet writes
+# per-container log files) is hostPath-mounted into the pod, plus
+# /var/lib/docker/containers for the legacy log path some
+# kubelets symlink to. emptyDir for the positions cursor (so a
+# Promtail restart doesn't re-ship everything from the start of the
+# file).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: go-micro-example
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /run/promtail/positions.yaml
+
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        # The kubelet writes container logs in CRI multi-line format
+        # under /var/log/pods; this pipeline stage strips the CRI
+        # header so the Loki line is just the application log body.
+        pipeline_stages:
+          - cri: {}
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          # Extract a stable `app` label from a small priority list:
+          # the OPS-004 base sets app.kubernetes.io/name; older charts
+          # set `app`; everything else falls back to the pod name.
+          - source_labels:
+              - __meta_kubernetes_pod_label_app_kubernetes_io_name
+              - __meta_kubernetes_pod_label_app
+              - __meta_kubernetes_pod_name
+            regex: ^;*([^;]+)(;.*)?$
+            action: replace
+            target_label: app
+          - source_labels:
+              - __meta_kubernetes_namespace
+            action: replace
+            target_label: namespace
+          - source_labels:
+              - __meta_kubernetes_pod_name
+            action: replace
+            target_label: pod
+          - source_labels:
+              - __meta_kubernetes_pod_container_name
+            action: replace
+            target_label: container
+          - source_labels:
+              - __meta_kubernetes_pod_node_name
+            action: replace
+            target_label: node
+          # The kubelet writes each container's logs to
+          # /var/log/pods/<namespace>_<pod>_<uid>/<container>/*.log.
+          # Build that path from labels so Promtail tails the right
+          # files on the hostPath mount.
+          - action: replace
+            replacement: /var/log/pods/*$1/*.log
+            separator: /
+            source_labels:
+              - __meta_kubernetes_pod_uid
+              - __meta_kubernetes_pod_container_name
+            target_label: __path__
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  labels:
+    app.kubernetes.io/name: promtail
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: promtail
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: promtail
+    spec:
+      serviceAccountName: promtail
+      # Tolerate any node taint — kind doesn't add any by default, but
+      # this lets the DaemonSet also schedule on a control-plane node
+      # if a future multi-node kind config is used.
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.5.1
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          ports:
+            - name: http
+              containerPort: 9080
+              protocol: TCP
+          env:
+            # Used by the Promtail config / journal stage; not strictly
+            # required for the kubernetes_sd_configs path above but
+            # cheap to expose.
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+              readOnly: true
+            - name: positions
+              mountPath: /run/promtail
+            - name: pod-logs
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            # Promtail needs to read the kubelet's pod log directory,
+            # which is owned by root. readOnlyRootFilesystem stays
+            # off because the in-memory positions cursor lives at
+            # /run/promtail; the volume mount above covers writes.
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - DAC_READ_SEARCH
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: positions
+          emptyDir: {}
+        - name: pod-logs
+          hostPath:
+            path: /var/log/pods
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers


### PR DESCRIPTION
## Summary

Lands a single-replica Prometheus that scrapes via the OPS-004
`prometheus.io/scrape` annotation, plus a Grafana Prometheus
datasource and a starter metrics dashboard. Depends on
[#100](https://github.com/sksmith/go-micro-example/pull/100)
(K8S-011) for the Grafana install — this PR is stacked on top of
that branch.

- `deploy/overlays/local/prometheus.yaml` — `prom/prometheus:v3.6.0`,
  read-only ClusterRole for `kubernetes_sd_configs (role=pod)`,
  annotation-driven scrape, 2 h retention on an emptyDir. Pod
  labelled `app.kubernetes.io/name: prometheus` to match the base
  NetworkPolicy ingress allow-list.
- `deploy/overlays/local/grafana.yaml` — adds a Prometheus
  datasource (uid=Prometheus) alongside the existing Loki one
  (uid=Loki), plus a "go-micro-example metrics" dashboard.
- `make k8s-local-ui-prometheus` — port-forwards `svc/prometheus
  9090:9090`.
- README — adds a **Metrics UI** subsection and the new file to
  the directory tree.

Ticket: `plan/K8S-012-metrics-ui-prometheus.md`.

## Dashboard panels

- HTTP RPS by route (`url_hit_count`)
- HTTP latency p99 by route (`url_latency`)
- Goroutines (`go_goroutines`)
- Heap in use (`go_memstats_heap_inuse_bytes`)
- GC pause p99 (`go_gc_duration_seconds`)
- SEC-002b Basic Auth counter (`auth_basic_auth_attempts_total`)

## Acceptance criteria

- [x] Prometheus `/targets` shows the app pods as `UP`, scraped via
  the annotation.
- [x] `sum(rate(url_hit_count[1m])) by (url)` returns non-zero
  values after `make k8s-local-loadtest`.
- [x] Grafana's starter dashboard renders all six panels.

## Test plan

- [ ] `kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local` renders cleanly.
- [ ] `make k8s-local-up` brings Prometheus up.
- [ ] `make k8s-local-ui-prometheus` → `/targets` is green for the
  app pod.
- [ ] `make k8s-local-loadtest` for 30 s, confirm the dashboard
  fills in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)