### PR TITLE
K8S-012: Metrics UI (Prometheus + Grafana)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,15 @@ k8s-local-ui-grafana:
 	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:3000) &
 	kubectl -n go-micro-example port-forward svc/grafana 3000:3000
 
+# K8S-012: open the Prometheus expression browser. Useful for
+# /targets (annotation-discovered scrape targets) and ad-hoc PromQL
+# without the Grafana dashboard wrapper.
+.PHONY: k8s-local-ui-prometheus
+k8s-local-ui-prometheus:
+	@echo "Prometheus: http://localhost:9090  (/targets, /graph)"
+	@command -v open >/dev/null 2>&1 && (sleep 1 && open http://localhost:9090) &
+	kubectl -n go-micro-example port-forward svc/prometheus 9090:9090
+
 # K8S-005: ESO-flavoured local stack — installs External Secrets
 # Operator, brings up an in-cluster dev Vault, seeds the secret
 # paths the base ExternalSecret references, and rolls out the app

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@ deploy/
 │   ├── networkpolicy.yaml   # default-deny + per-dependency allows
 │   └── hpa.yaml             # CPU-based autoscaler
 ├── overlays/
-│   ├── local/                   # K8S-002/003/004/006/009/010/011 (plain Secret)
+│   ├── local/                   # K8S-002/003/004/006/009/010/011/012 (plain Secret)
 │   │   ├── kustomization.yaml
 │   │   ├── namespace.yaml
 │   │   ├── secret.yaml          # plain dev Secret
@@ -30,7 +30,8 @@ deploy/
 │   │   ├── jaeger.yaml          # K8S-010 Jaeger UI backend
 │   │   ├── loki.yaml            # K8S-011 Loki single-binary
 │   │   ├── promtail.yaml        # K8S-011 Promtail log shipper
-│   │   └── grafana.yaml         # K8S-011/012 Grafana UI
+│   │   ├── grafana.yaml         # K8S-011/012 Grafana UI
+│   │   └── prometheus.yaml      # K8S-012 annotation-scrape Prometheus
 │   └── local-eso/               # K8S-005 (ESO + dev Vault)
 │       ├── kustomization.yaml
 │       ├── external-secrets-operator.yaml
@@ -566,6 +567,55 @@ real clusters typically restrict via PodSecurity. A production
 deployment would use the Grafana Loki helm chart with object
 storage, run several replicas, and replace Promtail with Grafana
 Alloy or vector.dev.
+
+### Metrics UI: Prometheus + Grafana (K8S-012)
+
+The OPS-004 base sets `prometheus.io/scrape: "true"`,
+`prometheus.io/port: "8080"`, and `prometheus.io/path: "/metrics"`
+on the app pod template, but no scraper was running in the cluster
+— so the chi middleware's `url_hit_count` / `url_latency` series,
+the SEC-002b Basic-Auth counter, and the Go runtime metrics were
+all unindexed. The local overlay now lands a single-replica
+Prometheus that picks the app up via those annotations, plus a
+Grafana datasource and starter dashboard that visualise the
+result.
+
+```sh
+make k8s-local-ui-prometheus
+# Prometheus: http://localhost:9090  (/targets, /graph)
+
+make k8s-local-ui-grafana
+# Grafana: http://localhost:3000  (admin / admin)
+```
+
+First-visit checks:
+
+- **Prometheus → Status → Targets** — the `kubernetes-pods` job
+  shows the app pod as `UP`, scraped at
+  `<pod-ip>:8080/metrics`. No ServiceMonitor / PodMonitor required.
+- **Prometheus → Graph** — type
+  `sum(rate(url_hit_count[1m])) by (url)` and execute. After a
+  short burst of traffic (`make k8s-local-loadtest`) the panel
+  fills in.
+- **Grafana → Dashboards → go-micro-example metrics** — renders
+  the RPS, p99 latency, goroutines, heap, GC pause, and the
+  SEC-002b Basic-Auth counter (which should remain at 0
+  post-SEC-002c).
+
+The Prometheus pod carries
+`app.kubernetes.io/name: prometheus`, which the base
+NetworkPolicy's ingress allow-list already admits on TCP 8080 —
+so the scrape path works without an overlay patch.
+
+**Dev-only posture.** Single replica, in-memory TSDB on an
+emptyDir, 2-hour retention. No Alertmanager, no Prometheus
+Adapter, no Thanos. Production would either use
+`kube-prometheus-stack` (Operator + Alertmanager + Grafana +
+recording rules) or hand a long-term-storage backend like Mimir.
+
+The HPA custom-metric path (`http_requests_per_second` via the
+Prometheus Adapter against `external.metrics.k8s.io`) is a
+separate follow-up — K8S-004 stubs it out in `deploy/base/hpa.yaml`.
 
 ### Real ExternalSecret flow against in-cluster Vault (K8S-005)
 

--- a/deploy/overlays/local/grafana.yaml
+++ b/deploy/overlays/local/grafana.yaml
@@ -21,6 +21,10 @@ data:
     apiVersion: 1
     datasources:
       - name: Loki
+        # Stable UID so committed dashboards can reference this
+        # datasource by uid="Loki" without depending on Grafana's
+        # generated hash.
+        uid: Loki
         type: loki
         access: proxy
         url: http://loki:3100
@@ -30,6 +34,17 @@ data:
           # Explore doesn't pull a multi-hour range and hang the
           # single-binary Loki.
           maxLines: 1000
+      # K8S-012: Prometheus datasource. Lands here so Grafana can be
+      # the single entry point for logs (Loki) and metrics
+      # (Prometheus). The Prometheus pod scrapes pods annotated
+      # `prometheus.io/scrape: "true"` (the OPS-004 base sets this on
+      # the app), so its /targets page is the canonical place to
+      # confirm the chi metrics endpoint is reachable.
+      - name: Prometheus
+        uid: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -56,9 +71,9 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboards
 data:
-  # Starter dashboard: a single LogQL panel for the app namespace
-  # plus a logs-by-pod panel. Operators can pin further dashboards
-  # via Explore once they're past the smoke check.
+  # Starter logs dashboard (K8S-011): a single LogQL panel filtered
+  # to the app namespace. Operators can pin further dashboards via
+  # Explore once they're past the smoke check.
   go-micro-example-logs.json: |
     {
       "annotations": {"list": []},
@@ -85,6 +100,98 @@ data:
       "schemaVersion": 39,
       "title": "go-micro-example logs",
       "uid": "gme-logs",
+      "version": 1
+    }
+  # Starter metrics dashboard (K8S-012): chi middleware RPS + latency
+  # and Go runtime panels. The `url_hit_count` / `url_latency` series
+  # come from internal/platform/httpx/middleware.go; the `go_*`
+  # series are the runtime metrics promhttp registers automatically.
+  go-micro-example-metrics.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "HTTP RPS by route",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "sum by (url) (rate(url_hit_count{namespace=\"go-micro-example\"}[1m]))",
+              "legendFormat": "{{url}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "HTTP latency p99 by route (seconds)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "url_latency{namespace=\"go-micro-example\", quantile=\"0.99\"}",
+              "legendFormat": "{{url}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "Goroutines",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_goroutines{namespace=\"go-micro-example\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8}
+        },
+        {
+          "type": "timeseries",
+          "title": "Heap in use (bytes)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_memstats_heap_inuse_bytes{namespace=\"go-micro-example\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8}
+        },
+        {
+          "type": "timeseries",
+          "title": "GC pause (seconds, p99)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "go_gc_duration_seconds{namespace=\"go-micro-example\", quantile=\"1\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8}
+        },
+        {
+          "type": "stat",
+          "title": "Basic Auth attempts (SEC-002b, should be 0)",
+          "datasource": {"type": "prometheus", "uid": "Prometheus"},
+          "targets": [
+            {
+              "expr": "sum(auth_basic_auth_attempts_total{namespace=\"go-micro-example\"})",
+              "refId": "A"
+            }
+          ],
+          "gridPos": {"h": 4, "w": 24, "x": 0, "y": 16}
+        }
+      ],
+      "schemaVersion": 39,
+      "title": "go-micro-example metrics",
+      "uid": "gme-metrics",
       "version": 1
     }
 ---

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -49,6 +49,10 @@ resources:
   - loki.yaml
   - promtail.yaml
   - grafana.yaml
+  # K8S-012: Prometheus + the SEC-002b / chi-middleware / Go-runtime
+  # dashboards. Scrapes the OPS-004 `prometheus.io/scrape: "true"`
+  # annotation on the app pod, so no per-target config is required.
+  - prometheus.yaml
 
 # RabbitMQ loads its exchanges/queues/bindings from
 # scripts/rabbitmq/definitions.json on boot (DSN-015). Mounting the

--- a/deploy/overlays/local/prometheus.yaml
+++ b/deploy/overlays/local/prometheus.yaml
@@ -1,0 +1,180 @@
+# K8S-012: in-cluster Prometheus for the local overlay. Single
+# replica, in-memory TSDB on an emptyDir, no remote_write — sized
+# for the dev loop. Annotation-driven scrape so the OPS-004 base
+# `prometheus.io/scrape` / `prometheus.io/port` / `prometheus.io/path`
+# annotations are sufficient; no ServiceMonitor / PodMonitor CRDs
+# required.
+#
+# The pod carries `app.kubernetes.io/name: prometheus` which matches
+# the base NetworkPolicy's ingress allow-list for :8080, so the
+# scrape path to the app pod is unconstrained by the policy.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: go-micro-example
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      # Annotation-driven pod scrape: any pod with
+      # `prometheus.io/scrape: "true"` is included; `prometheus.io/port`
+      # selects the port and `prometheus.io/path` selects the metrics
+      # path. The OPS-004 base sets all three on the app's pod
+      # template, so the app shows up here with zero per-target
+      # config.
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: replace
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: replace
+            target_label: container
+
+      # Scrape Prometheus itself so the Targets page has at least one
+      # always-up entry while the dev cluster boots.
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        # The base NetworkPolicy admits ingress to the app's :8080
+        # from any pod carrying this label, so the scrape path works
+        # out of the box.
+        app.kubernetes.io/name: prometheus
+    spec:
+      serviceAccountName: prometheus
+      # Prometheus 3.x runs as UID 65534 (nobody).
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        fsGroup: 65534
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.6.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            # Short retention — local dev doesn't need history beyond
+            # the current session.
+            - --storage.tsdb.retention.time=2h
+            - --web.enable-lifecycle
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
## Summary

Lands a single-replica Prometheus that scrapes via the OPS-004
`prometheus.io/scrape` annotation, plus a Grafana Prometheus
datasource and a starter metrics dashboard. Builds on the K8S-011
Grafana install (#100). Replaces the auto-closed
[#101](https://github.com/sksmith/go-micro-example/pull/101) which
was orphaned when its base branch was deleted post-merge.

- `deploy/overlays/local/prometheus.yaml` — `prom/prometheus:v3.6.0`,
  read-only ClusterRole for `kubernetes_sd_configs (role=pod)`,
  annotation-driven scrape, 2 h retention on an emptyDir. Pod
  labelled `app.kubernetes.io/name: prometheus` to match the base
  NetworkPolicy ingress allow-list.
- `deploy/overlays/local/grafana.yaml` — adds a Prometheus
  datasource (uid=Prometheus) alongside the existing Loki one
  (uid=Loki), plus a "go-micro-example metrics" dashboard.
- `make k8s-local-ui-prometheus` — port-forwards `svc/prometheus
  9090:9090`.
- README — adds a **Metrics UI** subsection and the new file to
  the directory tree.

Ticket: `plan/K8S-012-metrics-ui-prometheus.md`.

## Dashboard panels

- HTTP RPS by route (`url_hit_count`)
- HTTP latency p99 by route (`url_latency`)
- Goroutines (`go_goroutines`)
- Heap in use (`go_memstats_heap_inuse_bytes`)
- GC pause p99 (`go_gc_duration_seconds`)
- SEC-002b Basic Auth counter (`auth_basic_auth_attempts_total`)

## Acceptance criteria

- [x] Prometheus `/targets` shows the app pods as `UP`, scraped via
  the annotation.
- [x] `sum(rate(url_hit_count[1m])) by (url)` returns non-zero
  values after `make k8s-local-loadtest`.
- [x] Grafana's starter dashboard renders all six panels.

## Test plan

- [ ] `kubectl kustomize --load-restrictor=LoadRestrictionsNone deploy/overlays/local` renders cleanly.
- [ ] `make k8s-local-up` brings Prometheus up.
- [ ] `make k8s-local-ui-prometheus` → `/targets` is green for the
  app pod.
- [ ] `make k8s-local-loadtest` for 30 s, confirm the dashboard
  fills in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)