### PR TITLE
TST-006: echo X-Request-Id + X-Trace-Id on every response

### DIFF
--- a/internal/app/correlation_integration_test.go
+++ b/internal/app/correlation_integration_test.go
@@ -44,6 +44,28 @@ func TestCorrelationLogger_PropagatesXRequestID(t *testing.T) {
 	}
 }
 
+func TestCorrelationLogger_EchoesXRequestIDHeader(t *testing.T) {
+	r, _ := newTestRouter()
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+app.LivenessEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Request-Id", "trace-echo-1")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = res.Body.Close()
+
+	if got := res.Header.Get("X-Request-Id"); got != "trace-echo-1" {
+		t.Errorf("X-Request-Id response header = %q, want %q", got, "trace-echo-1")
+	}
+}
+
 func TestCorrelationLogger_GeneratesIDWhenAbsent(t *testing.T) {
 	var buf bytes.Buffer
 	original := log.Logger

--- a/internal/platform/httpx/middleware.go
+++ b/internal/platform/httpx/middleware.go
@@ -19,17 +19,30 @@ import (
 // request_id (and trace_id/span_id when an OTel span is recording)
 // without threading those values manually. Mount AFTER chi's RequestID
 // and otelchi middleware so both IDs are available.
+//
+// It also echoes the request and trace IDs back to the caller as
+// X-Request-Id / X-Trace-Id response headers so external observers
+// (the DSN-027 operator-console UI, retry middleware, support
+// scripts, curl debugging) can correlate the response to the same
+// span the server logged. Headers are written before the handler
+// runs so they survive even when the handler returns an error and
+// flushes its own status code immediately.
 func CorrelationLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		reqID := middleware.GetReqID(ctx)
 		ctx = observability.ContextWithRequestID(ctx, reqID)
 
+		if reqID != "" {
+			w.Header().Set("X-Request-Id", reqID)
+		}
+
 		zctx := log.With().Str("request_id", reqID)
 		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
 			zctx = zctx.
 				Str("trace_id", sc.TraceID().String()).
 				Str("span_id", sc.SpanID().String())
+			w.Header().Set("X-Trace-Id", sc.TraceID().String())
 		}
 		logger := zctx.Logger()
 		next.ServeHTTP(w, r.WithContext(logger.WithContext(ctx)))


### PR DESCRIPTION
## Summary

\`CorrelationLogger\` already pulled \`request_id\` and \`trace_id\` into the request-scoped logger so log lines correlate. It never wrote either back to the response, so external observers (the DSN-027 operator-console UI, retry middleware, support scripts, curl debugging) had no way to recover the trace ID for a given response. The UI's live Jaeger span-tree pane stayed permanently on the muted \"no trace id\" note.

Fix: set \`X-Request-Id\` from chi's \`middleware.GetReqID\` and \`X-Trace-Id\` from the OTel \`SpanContext\` when one is recording. Headers are written before the handler runs so they survive when the handler flushes its own status code immediately (e.g. problem+json error responses).

## Test plan

- [x] New \`TestCorrelationLogger_EchoesXRequestIDHeader\` integration test
- [x] \`make fmt vet lint sec test-race\` — green
- [ ] Manual: hit a card in the operator console; trace-tree pane should resolve a real span tree from Jaeger instead of \"no trace id\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)