### PR TITLE
local overlay: allow egress to jaeger:16686 for the UI trace pane

### DIFF
--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -123,6 +123,21 @@ patches:
           ports:
             - protocol: TCP
               port: 8080
+      # Allow the DSN-027 operator-console pane to query the
+      # in-cluster Jaeger Query API on :16686. The base policy
+      # intentionally doesn't allow this — the UI is a dev/local
+      # feature gated by GME_UI_JAEGERQUERYURL and prod overlays
+      # leave that empty so this rule is never exercised there.
+      - op: add
+        path: /spec/egress/-
+        value:
+          to:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: jaeger
+          ports:
+            - protocol: TCP
+              port: 16686
   # Promote the base ClusterIP app Service to NodePort so kind's
   # extraPortMappings can publish http://localhost:8080. The base
   # Service stays ClusterIP-shaped for real deployments (the overlay


### PR DESCRIPTION
## Summary

DSN-027's scope-pane span tree pulls live trace data from the in-cluster Jaeger Query API. After [#107](https://github.com/sksmith/go-micro-example/pull/107) echoed \`X-Trace-Id\` back to the UI, the trace ID was reaching the renderer — but the base NetworkPolicy's default-deny egress was dropping the outbound call and the lookup timed out at 2s with \`context deadline exceeded\`.

The base policy is intentionally tight (prod posture — Jaeger isn't a runtime dependency there). Add a single-port egress allowance in the local overlay so the dev cluster's UI can resolve trace IDs end-to-end without weakening the prod manifest.

## Test plan

- [x] \`kubectl kustomize deploy/overlays/local\` renders cleanly with the new egress rule
- [ ] After redeploy, the scope pane shows an ASCII span tree instead of \"context deadline exceeded\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)