### PR TITLE
ui + local k8s: honest 'Production event' card + in-cluster Redpanda

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,6 +64,7 @@ kubectl -n go-micro-example get pods
 # go-micro-example-…   1/1   Running
 # postgres-…           1/1   Running
 # rabbitmq-…           1/1   Running
+# redpanda-…           1/1   Running
 # vault-…              1/1   Running
 # jaeger-…             1/1   Running
 # loki-…               1/1   Running

--- a/deploy/base/configmap.yaml
+++ b/deploy/base/configmap.yaml
@@ -49,6 +49,12 @@ data:
   GME_UI_ENABLED: "true"
   GME_UI_JAEGERQUERYURL: ""
 
+  # DSN-016: Kafka brokers (comma-separated bootstrap list). Empty
+  # disables the franz-go producer + consumer cleanly. The local
+  # overlay patches this to "redpanda:29092"; prod overlays should
+  # set it to their real bootstrap brokers.
+  GME_KAFKA_BROKERS: ""
+
   # OpenTelemetry. Empty endpoint installs a no-op provider so the
   # app starts cleanly even without a collector; set in the overlay
   # to point at your in-cluster collector.

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -21,10 +21,15 @@ namespace: go-micro-example
 
 resources:
   - ../../base
-  # Namespace + dev dependencies (Postgres, RabbitMQ).
+  # Namespace + dev dependencies (Postgres, RabbitMQ, Redpanda).
   - namespace.yaml
   - postgres.yaml
   - rabbitmq.yaml
+  # Redpanda is the local Kafka broker (single-node KRaft, Kafka-API
+  # compatible) that lets the DSN-016 producer/consumer demo exercise
+  # the Kafka transport without docker-compose. Prod overlays don't
+  # ship this — they point GME_KAFKA_BROKERS at a real cluster.
+  - redpanda.yaml
   # OTel collector. Receives the app's OTLP/gRPC spans and forwards
   # them to the `debug` exporter (stdout) and Jaeger (UI). See
   # otel-collector.yaml + the OTEL_EXPORTER_OTLP_ENDPOINT patch
@@ -138,6 +143,20 @@ patches:
           ports:
             - protocol: TCP
               port: 16686
+      # Allow the franz-go producer + consumer to reach the local
+      # Redpanda broker on its internal listener (:29092). Base
+      # policy doesn't allow this because prod overlays point
+      # GME_KAFKA_BROKERS at a managed Kafka outside the cluster.
+      - op: add
+        path: /spec/egress/-
+        value:
+          to:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: redpanda
+          ports:
+            - protocol: TCP
+              port: 29092
   # Promote the base ClusterIP app Service to NodePort so kind's
   # extraPortMappings can publish http://localhost:8080. The base
   # Service stays ClusterIP-shaped for real deployments (the overlay
@@ -173,6 +192,13 @@ patches:
       - op: replace
         path: /data/GME_UI_JAEGERQUERYURL
         value: http://jaeger:16686
+      # Point the franz-go producer + consumer at the in-cluster
+      # Redpanda broker. The internal listener is :29092 (mirrors
+      # docker-compose) so anyone running both stacks doesn't clash
+      # on host port 9092.
+      - op: replace
+        path: /data/GME_KAFKA_BROKERS
+        value: redpanda:29092
   - target:
       group: external-secrets.io
       version: v1

--- a/deploy/overlays/local/redpanda.yaml
+++ b/deploy/overlays/local/redpanda.yaml
@@ -1,0 +1,84 @@
+# Local overlay: single-node Redpanda for the DSN-016 Kafka transport.
+# Mirrors the docker-compose `redpanda` service so traces, schemas,
+# and behaviour stay consistent between the two demo stacks.
+#
+# Why Redpanda over upstream Kafka:
+# - Single binary, KRaft-only, boots in ~5s vs Kafka+Zookeeper's tens
+#   of seconds. The whole point of the local overlay is fast bring-up.
+# - Wire-compatible with the Kafka protocol — the franz-go client in
+#   internal/platform/messaging/kafka/ doesn't know the difference.
+#
+# Service name `redpanda` matches the ConfigMap's GME_KAFKA_BROKERS
+# patch (redpanda:29092); the in-cluster listener is :29092, kept
+# distinct from the external :9092 the docker-compose stack publishes
+# so anyone running both stacks side by side doesn't have a port
+# collision. No NodePort here — Redpanda is internal-only; the
+# admin/debug UI lives on its own and isn't exposed.
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redpanda
+  ports:
+    - name: kafka-internal
+      port: 29092
+      targetPort: 29092
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/name: redpanda
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redpanda
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redpanda
+    spec:
+      containers:
+        - name: redpanda
+          image: redpandadata/redpanda:v24.2.7
+          args:
+            - redpanda
+            - start
+            - --overprovisioned
+            - --smp=1
+            - --memory=512M
+            - --reserve-memory=0M
+            - --node-id=0
+            - --check=false
+            # Single internal listener; matches the franz-go
+            # bootstrap broker in GME_KAFKA_BROKERS.
+            - --kafka-addr=INTERNAL://0.0.0.0:29092
+            - --advertise-kafka-addr=INTERNAL://redpanda:29092
+          ports:
+            - name: kafka-internal
+              containerPort: 29092
+          # Readiness probe via rpk cluster info — only flips to Ready
+          # once Redpanda has elected itself controller and is willing
+          # to serve metadata requests. Without this the app pod can
+          # race the broker on startup and the kafka producer init
+          # fails before the cluster is reachable.
+          readinessProbe:
+            exec:
+              command: ["rpk", "cluster", "info", "-X", "brokers=localhost:29092"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -228,12 +228,12 @@ func capabilityCards() []CapabilityCard {
 		{
 			Slug:       "kafka-publish",
 			Ticket:     "DSN-016",
-			Title:      "Kafka publish",
-			Body:       "Emit a RecordProduction command, watch the outbound product-quantity-changed event land.",
+			Title:      "Production event",
+			Body:       "Record production for a SKU. The handler writes the production_events row, updates available, then publishes in parallel to RabbitMQ (inventory.exchange) and Kafka (product-quantity-changed.v1) when each is wired. Both producers are OTel-instrumented — their spans land under the same trace id.",
 			Method:     "PUT",
 			Path:       "/api/v1/inventory/{sku}/productionEvent",
 			NeedsAuth:  true,
-			BannerLine: "kafka.produce",
+			BannerLine: "amqp + kafka",
 		},
 		{
 			Slug:       "rest-outbound",

--- a/internal/web/testdata/index.golden.html
+++ b/internal/web/testdata/index.golden.html
@@ -82,9 +82,9 @@
     data-card="kafka-publish">
   <header class="card__head">
     <span class="card__id">DSN-016</span>
-    <h2 class="card__title">Kafka publish</h2>
+    <h2 class="card__title">Production event</h2>
   </header>
-  <p class="card__body">Emit a RecordProduction command, watch the outbound product-quantity-changed event land.</p>
+  <p class="card__body">Record production for a SKU. The handler writes the production_events row, updates available, then publishes in parallel to RabbitMQ (inventory.exchange) and Kafka (product-quantity-changed.v1) when each is wired. Both producers are OTel-instrumented — their spans land under the same trace id.</p>
   <div class="card__meta">
     <span class="card__verb card__verb--PUT">PUT</span>
     <span class="card__path">/api/v1/inventory/{sku}/productionEvent</span>
@@ -96,7 +96,7 @@
           hx-indicator="#card-kafka-publish">
     try it<span class="card__cta-cursor" aria-hidden="true">▌</span>
   </button>
-  <span class="card__banner" aria-hidden="true">kafka.produce</span>
+  <span class="card__banner" aria-hidden="true">amqp &#43; kafka</span>
 </li>
         
           <li class="card card--needs-auth"


### PR DESCRIPTION
## Summary

The \"Kafka publish\" UI card was misleading on the local k8s overlay because the cluster never had a Kafka broker — every click only exercised the DB write + AMQP publish path, with the Kafka emit quietly skipped (nil emitter when \`GME_KAFKA_BROKERS\` is empty). Fix both halves.

### 1. Honest card

- Rename **\"Kafka publish\" → \"Production event\"**.
- Body rewritten to say what the handler actually does: write \`production_events\`, update \`available\`, then publish in parallel to RabbitMQ (\`inventory.exchange\`) and Kafka (\`product-quantity-changed.v1\`) when each is wired.
- Both producers are already OTel-instrumented (DSN-004a for AMQP, \`kotel\` hooks for the franz-go producer), so their spans land under the same trace id and show up in the operator-console span tree.

### 2. In-cluster Kafka broker

- New \`deploy/overlays/local/redpanda.yaml\` — single-node Redpanda, mirrors the docker-compose \`redpanda\` service. Kafka-API compatible, ~5s boot, no Zookeeper.
- New \`GME_KAFKA_BROKERS\` key in the base ConfigMap (empty default, follows the OTEL/UI pattern).
- Local overlay patches \`GME_KAFKA_BROKERS\` to \`redpanda:29092\` and adds a NetworkPolicy egress allowance so the franz-go producer can actually reach the broker.

## Follow-up worth considering, not in this PR

The \"RabbitMQ\" card on the rail now hits the same endpoint as \"Production event\" — they're effectively duplicates. Either drop the RabbitMQ card or repurpose it to target a different surface. Worth a quick separate decision rather than bundling here.

## Test plan

- [x] \`make fmt vet lint sec test-race\` — green
- [x] \`kubectl kustomize deploy/overlays/local\` — renders cleanly with the new resource + patches
- [ ] After redeploy: \`Production event\` card fires; Jaeger trace shows the chi server span + the new \`kafka.produce\` producer span alongside the existing AMQP publish span

🤖 Generated with [Claude Code](https://claude.com/claude-code)