### PR TITLE
DSN-004a: hand kotel the global tracer provider (kafka spans)

### DIFF
--- a/internal/platform/messaging/kafka/consumer.go
+++ b/internal/platform/messaging/kafka/consumer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sksmith/go-micro-example/internal/platform/events"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kotel"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -56,7 +57,14 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 	}
 	ensureMetrics()
 
-	tracer := kotel.NewTracer(kotel.TracerProvider(nil))
+	// Same fix as producer.go: kotel.TracerProvider(nil) routes every
+	// span to a no-op tracer. Hand it the global provider so the
+	// consumer spans share the OTel pipeline that ships them to the
+	// collector and Jaeger.
+	tracer := kotel.NewTracer(
+		kotel.TracerProvider(otel.GetTracerProvider()),
+		kotel.TracerPropagator(otel.GetTextMapPropagator()),
+	)
 	hooks := kotel.NewKotel(kotel.WithTracer(tracer)).Hooks()
 
 	client, err := kgo.NewClient(

--- a/internal/platform/messaging/kafka/producer.go
+++ b/internal/platform/messaging/kafka/producer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sksmith/go-micro-example/internal/platform/events"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kotel"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
 
@@ -26,7 +27,16 @@ type Producer struct {
 // returned client is fully initialized; call Close on shutdown.
 func NewProducer(brokers []string, topic string) (*Producer, error) {
 	ensureMetrics()
-	tracer := kotel.NewTracer(kotel.TracerProvider(nil))
+	// kotel.TracerProvider(nil) tells kotel to use a no-op tracer,
+	// which silently drops every kafka.produce / kafka.consume span
+	// even though the hooks fire — that's why the DSN-027 trace tree
+	// never showed a producer span on Jaeger. Hand kotel the global
+	// provider that DSN-004 installed at startup so spans land in
+	// the same pipeline as the chi server and AMQP producer spans.
+	tracer := kotel.NewTracer(
+		kotel.TracerProvider(otel.GetTracerProvider()),
+		kotel.TracerPropagator(otel.GetTextMapPropagator()),
+	)
 	client, err := kgo.NewClient(
 		kgo.SeedBrokers(brokers...),
 		kgo.DefaultProduceTopic(topic),


### PR DESCRIPTION
## Summary

The Kafka producer and consumer both instantiated kotel with \`kotel.NewTracer(kotel.TracerProvider(nil))\`. Passing nil to kotel's \`TracerProvider\` option **explicitly** routes every span to a no-op tracer — the hooks fire, the \`traceparent\` header still gets stamped on outgoing records (verified via \`rpk topic consume\`), but the producer / consumer spans themselves never reach the OTel pipeline.

That's why the DSN-027 operator-console trace tree showed only the chi server span for a production event — every Kafka span was silently dropped.

Fix: hand kotel the global \`TracerProvider\` and \`Propagator\` that DSN-004 already installed at startup. franz-go's hooks now emit \`kafka.produce\` / \`kafka.consume\` spans into the same exporter pipeline as the chi server and AMQP producer spans, so they appear under the same trace id in Jaeger.

## Test plan

- [x] \`make fmt vet lint sec test-race\` — green
- [ ] Manual: \`Production event\` card → scope pane trace tree shows the chi server span + kafka.produce span + AMQP publish span under the same trace id

🤖 Generated with [Claude Code](https://claude.com/claude-code)